### PR TITLE
Fix formatting of workload IDs in workload list command

### DIFF
--- a/internal/pkg/workload/workload.go
+++ b/internal/pkg/workload/workload.go
@@ -54,7 +54,7 @@ func GetRegisteredWorkloads(ctx context.Context, kubeConfig string, kubeContext 
 			registeredWorkload := &Workload{
 				Name:      pod.Name,
 				Namespace: pod.Namespace,
-				SPIFFEID:  registeredEntry.Id.String(),
+				SPIFFEID:  registeredEntry.Id,
 				Status:    string(pod.Status.Phase),
 				Type:      "Pod",
 			}


### PR DESCRIPTION
Previously they were displayed as:

  trust_domain:"td1" path:"/ns/ns3/sa/default"

Now they are displayed as a URL:

  spiffe://td1/ns/ns3/sa/default
