### PR TITLE
Disable federation by default

### DIFF
--- a/internal/pkg/provider/helm/values.go
+++ b/internal/pkg/provider/helm/values.go
@@ -58,7 +58,6 @@ func (g *HelmValuesGenerator) GenerateValues() (map[string]interface{}, error) {
 	}
 
 	spireServerValues := map[string]interface{}{
-		`"spire-server"."federation"."enabled"`:        true,
 		`"spire-server"."service"."type"`:              "LoadBalancer",
 		`"spire-server"."caKeyType"`:                   "rsa-2048",
 		`"spire-server"."controllerManager"."enabled"`: true,

--- a/internal/pkg/provider/helm/values_test.go
+++ b/internal/pkg/provider/helm/values_test.go
@@ -91,9 +91,6 @@ func TestHelmValuesGenerator_GenerateValues_success(t *testing.T) {
 							},
 						},
 					},
-					"federation": Values{
-						"enabled": true,
-					},
 					"fullnameOverride": "spire-server",
 					"logLevel":         "DEBUG",
 					"nodeAttestor": Values{


### PR DESCRIPTION
Federation is now only enabled when a trust zone has a federation
relationship with another trust zone.

Fixes: #26
