### PR TITLE
Raname golangci-lint name

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
-      - name: Install golangci-lint
+      - name: Run golangci-lint
         uses: golangci/golangci-lint-action@v6
         with:
           args: --timeout=5m


### PR DESCRIPTION
Rename the step to Run golangci-lint so it is more clear when it fails that it isn't just the install that failed.