### PR TITLE
Wait for SPIRE server pod & service after post-install config

### DIFF
--- a/cmd/cofidectl/cmd/up.go
+++ b/cmd/cofidectl/cmd/up.go
@@ -69,6 +69,11 @@ func (u *UpCommand) UpCmd() *cobra.Command {
 				return err
 			}
 
+			// Wait for spire-server to be ready again.
+			if err := watchAndConfigure(cmd.Context(), ds, trustZones); err != nil {
+				return err
+			}
+
 			return nil
 		},
 	}


### PR DESCRIPTION
After #27 merged we started seeing failures in the federation
integration test:

  cofidectl workload discover
  Error: failed to stream exec: Internal error occurred: unable to upgrade connection: container not found ("spire-server")
  error: Recipe `integration-test` failed on line 20 with exit code 1

In #27 the Helm configuration was changed to only enable federation in
SPIRE server when there is a federation relationship that has a bundle
endpoint available. On the initial Helm install this would not be the
case, so federation would be disabled. On the post-install configure
Helm install, we would have bundle endpoints and so federation would be
enabled and SPIRE server would be restarted. This caused any commands
running immediately after cofidectl up that rely on SPIRE server being
up (in this case `cofidectl workload discover`) to fail.

This change addresses the issue by waiting for the SPIRE server pod and
service to be ready after the post-install configuration step.

Fixes: #36
