### PR TITLE
Fix wait_for_pong in integration tests

### DIFF
--- a/tests/integration/federation/test.sh
+++ b/tests/integration/federation/test.sh
@@ -58,6 +58,7 @@ function show_status() {
 
 function run_tests() {
   just -f demos/Justfile prompt_namespace=no deploy-ping-pong $K8S_CLUSTER_1_CONTEXT $K8S_CLUSTER_2_CONTEXT
+  kubectl --context $K8S_CLUSTER_1_CONTEXT wait -n demo --for=condition=Available --timeout 60s deployments/ping-pong-client
   if ! wait_for_pong; then
     echo "Timed out waiting for pong from server"
     echo "Client logs:"
@@ -69,13 +70,13 @@ function run_tests() {
 }
 
 function wait_for_pong() {
-  kubectl --context $K8S_CLUSTER_1_CONTEXT wait -n demo --for=condition=Available --timeout 60s deployments/ping-pong-client
   for i in $(seq 30); do
     if kubectl --context $K8S_CLUSTER_1_CONTEXT logs -n demo deployments/ping-pong-client | grep pong; then
-      return
+      return 0
     fi
     sleep 2
   done
+  return 1
 }
 
 function down() {

--- a/tests/integration/single-trust-zone/test.sh
+++ b/tests/integration/single-trust-zone/test.sh
@@ -46,6 +46,7 @@ function show_status() {
 
 function run_tests() {
   just -f demos/Justfile prompt_namespace=no deploy-ping-pong $K8S_CLUSTER_CONTEXT
+  kubectl --context $K8S_CLUSTER_CONTEXT wait -n demo --for=condition=Available --timeout 60s deployments/ping-pong-client
   if ! wait_for_pong; then
     echo "Timed out waiting for pong from server"
     echo "Client logs:"
@@ -57,13 +58,13 @@ function run_tests() {
 }
 
 function wait_for_pong() {
-  kubectl --context $K8S_CLUSTER_CONTEXT wait -n demo --for=condition=Available --timeout 60s deployments/ping-pong-client
   for i in $(seq 30); do
     if kubectl --context $K8S_CLUSTER_CONTEXT logs -n demo deployments/ping-pong-client | grep pong; then
-      return
+      return 0
     fi
     sleep 2
   done
+  return 1
 }
 
 function down() {


### PR DESCRIPTION
wait_for_pong needs to return 1 when retries are exhausted in order to
signal failure.

The kubectl wait exit code was being ignored because wait_for_pong is
called as an if conditional. Pull it out of wait_for_pong. Some context
on the issue:
https://stratus3d.com/blog/2019/11/29/bash-errexit-inconsistency/
