### PR TITLE
Implement full data source gRPC client and service

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.22.7
 require (
 	buf.build/go/protoyaml v0.2.0
 	cuelang.org/go v0.10.1
-	github.com/cofide/cofide-api-sdk v0.3.1-0.20241129154200-55cc6a78ce12
+	github.com/cofide/cofide-api-sdk v0.3.1-0.20241204134958-1bc361de13ce
 	github.com/fatih/color v1.18.0
 	github.com/gofrs/flock v0.12.1
 	github.com/google/go-cmp v0.6.0

--- a/go.sum
+++ b/go.sum
@@ -84,8 +84,8 @@ github.com/cncf/xds/go v0.0.0-20211001041855-01bcc9b48dfe/go.mod h1:eXthEFrGJvWH
 github.com/cncf/xds/go v0.0.0-20211011173535-cb28da3451f1/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
 github.com/cockroachdb/apd/v3 v3.2.1 h1:U+8j7t0axsIgvQUqthuNm82HIrYXodOV2iWLWtEaIwg=
 github.com/cockroachdb/apd/v3 v3.2.1/go.mod h1:klXJcjp+FffLTHlhIG69tezTDvdP065naDsHzKhYSqc=
-github.com/cofide/cofide-api-sdk v0.3.1-0.20241129154200-55cc6a78ce12 h1:pnmORvcGECcJEvxe95JfyGgSlTBViizTVW8LD4F7t+A=
-github.com/cofide/cofide-api-sdk v0.3.1-0.20241129154200-55cc6a78ce12/go.mod h1:yKMfhL3qCIVJcKvgZsPZC1o60/8co6/0NsCaJtrUoFY=
+github.com/cofide/cofide-api-sdk v0.3.1-0.20241204134958-1bc361de13ce h1:0EDn4+tPs1qdNH8SlavFZCD5/AcFgQsjBy21QG/D1QM=
+github.com/cofide/cofide-api-sdk v0.3.1-0.20241204134958-1bc361de13ce/go.mod h1:yKMfhL3qCIVJcKvgZsPZC1o60/8co6/0NsCaJtrUoFY=
 github.com/containerd/cgroups v1.1.0 h1:v8rEWFl6EoqHB+swVNjVoCJE8o3jX7e8nqBGPLaDFBM=
 github.com/containerd/cgroups v1.1.0/go.mod h1:6ppBcbh/NOOUU+dMKrykgaBnK9lCIBxHqJDGwsa1mIw=
 github.com/containerd/containerd v1.7.23 h1:H2CClyUkmpKAGlhQp95g2WXHfLYc7whAuvZGBNYOOwQ=

--- a/pkg/plugin/grpc.go
+++ b/pkg/plugin/grpc.go
@@ -13,6 +13,9 @@ import (
 	trust_zone_proto "github.com/cofide/cofide-api-sdk/gen/go/proto/trust_zone/v1alpha1"
 )
 
+// Type check to ensure DataSourcePluginClientGRPC implements DataSource.
+var _ DataSource = &DataSourcePluginClientGRPC{}
+
 // DataSourcePluginClientGRPC is used by clients (main application) to translate the
 // DataSource interface of plugins to GRPC calls.
 type DataSourcePluginClientGRPC struct {
@@ -21,13 +24,17 @@ type DataSourcePluginClientGRPC struct {
 }
 
 func (c *DataSourcePluginClientGRPC) Validate() error {
-	// Unimplemented.
-	return nil
+	_, err := c.client.Validate(c.ctx, &cofidectl_proto.ValidateRequest{})
+	return err
 }
 
 func (c *DataSourcePluginClientGRPC) GetTrustZone(name string) (*trust_zone_proto.TrustZone, error) {
-	// Unimplemented.
-	return nil, nil
+	resp, err := c.client.GetTrustZone(c.ctx, &cofidectl_proto.GetTrustZoneRequest{Name: &name})
+	if err != nil {
+		return nil, err
+	}
+
+	return resp.TrustZone, nil
 }
 
 func (c *DataSourcePluginClientGRPC) ListTrustZones() ([]*trust_zone_proto.TrustZone, error) {
@@ -40,51 +47,83 @@ func (c *DataSourcePluginClientGRPC) ListTrustZones() ([]*trust_zone_proto.Trust
 }
 
 func (c *DataSourcePluginClientGRPC) AddTrustZone(trustZone *trust_zone_proto.TrustZone) (*trust_zone_proto.TrustZone, error) {
-	// Unimplemented.
-	return nil, nil
+	resp, err := c.client.AddTrustZone(c.ctx, &cofidectl_proto.AddTrustZoneRequest{TrustZone: trustZone})
+	if err != nil {
+		return nil, err
+	}
+
+	return resp.TrustZone, nil
 }
 
-func (c *DataSourcePluginClientGRPC) UpdateTrustZone(*trust_zone_proto.TrustZone) error {
-	// Unimplemented.
-	return nil
+func (c *DataSourcePluginClientGRPC) UpdateTrustZone(trustZone *trust_zone_proto.TrustZone) error {
+	_, err := c.client.UpdateTrustZone(c.ctx, &cofidectl_proto.UpdateTrustZoneRequest{TrustZone: trustZone})
+	return err
 }
 
-func (c *DataSourcePluginClientGRPC) AddAttestationPolicy(*attestation_policy_proto.AttestationPolicy) (*attestation_policy_proto.AttestationPolicy, error) {
-	// Unimplemented.
-	return nil, nil
+func (c *DataSourcePluginClientGRPC) AddAttestationPolicy(policy *attestation_policy_proto.AttestationPolicy) (*attestation_policy_proto.AttestationPolicy, error) {
+	resp, err := c.client.AddAttestationPolicy(c.ctx, &cofidectl_proto.AddAttestationPolicyRequest{Policy: policy})
+	if err != nil {
+		return nil, err
+	}
+
+	return resp.Policy, nil
 }
 
-func (c *DataSourcePluginClientGRPC) GetAttestationPolicy(string) (*attestation_policy_proto.AttestationPolicy, error) {
-	// Unimplemented.
-	return nil, nil
+func (c *DataSourcePluginClientGRPC) GetAttestationPolicy(name string) (*attestation_policy_proto.AttestationPolicy, error) {
+	resp, err := c.client.GetAttestationPolicy(c.ctx, &cofidectl_proto.GetAttestationPolicyRequest{Name: &name})
+	if err != nil {
+		return nil, err
+	}
+
+	return resp.Policy, nil
 }
 
 func (c *DataSourcePluginClientGRPC) ListAttestationPolicies() ([]*attestation_policy_proto.AttestationPolicy, error) {
-	// Unimplemented.
-	return nil, nil
+	resp, err := c.client.ListAttestationPolicies(c.ctx, &cofidectl_proto.ListAttestationPoliciesRequest{})
+	if err != nil {
+		return nil, err
+	}
+
+	return resp.Policies, nil
 }
 
-func (c *DataSourcePluginClientGRPC) AddAPBinding(*ap_binding_proto.APBinding) (*ap_binding_proto.APBinding, error) {
-	// Unimplemented.
-	return nil, nil
+func (c *DataSourcePluginClientGRPC) AddAPBinding(binding *ap_binding_proto.APBinding) (*ap_binding_proto.APBinding, error) {
+	resp, err := c.client.AddAPBinding(c.ctx, &cofidectl_proto.AddAPBindingRequest{Binding: binding})
+	if err != nil {
+		return nil, err
+	}
+
+	return resp.Binding, nil
 }
 
-func (c *DataSourcePluginClientGRPC) DestroyAPBinding(*ap_binding_proto.APBinding) error {
-	// Unimplemented.
-	return nil
+func (c *DataSourcePluginClientGRPC) DestroyAPBinding(binding *ap_binding_proto.APBinding) error {
+	_, err := c.client.DestroyAPBinding(c.ctx, &cofidectl_proto.DestroyAPBindingRequest{Binding: binding})
+	return err
 }
 
-func (c *DataSourcePluginClientGRPC) AddFederation(*federation_proto.Federation) (*federation_proto.Federation, error) {
-	// Unimplemented.
-	return nil, nil
+func (c *DataSourcePluginClientGRPC) AddFederation(federation *federation_proto.Federation) (*federation_proto.Federation, error) {
+	resp, err := c.client.AddFederation(c.ctx, &cofidectl_proto.AddFederationRequest{Federation: federation})
+	if err != nil {
+		return nil, err
+	}
+
+	return resp.Federation, nil
 }
 
 func (c *DataSourcePluginClientGRPC) ListFederations() ([]*federation_proto.Federation, error) {
-	// Unimplemented.
-	return nil, nil
+	resp, err := c.client.ListFederations(c.ctx, &cofidectl_proto.ListFederationsRequest{})
+	if err != nil {
+		return nil, err
+	}
+
+	return resp.Federations, nil
 }
 
 func (c *DataSourcePluginClientGRPC) ListFederationsByTrustZone(string) ([]*federation_proto.Federation, error) {
-	// Unimplemented.
-	return nil, nil
+	resp, err := c.client.ListFederationsByTrustZone(c.ctx, &cofidectl_proto.ListFederationsByTrustZoneRequest{})
+	if err != nil {
+		return nil, err
+	}
+
+	return resp.Federations, nil
 }

--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -45,23 +45,106 @@ type GRPCServer struct {
 	Impl DataSource
 }
 
-func (s *GRPCServer) ListTrustZones(ctx context.Context, req *cofidectl_proto.ListTrustZonesRequest) (*cofidectl_proto.ListTrustZonesResponse, error) {
-	resp, err := s.Impl.ListTrustZones()
+func (s *GRPCServer) Validate(_ context.Context, req *cofidectl_proto.ValidateRequest) (*cofidectl_proto.ValidateResponse, error) {
+	err := s.Impl.Validate()
 	if err != nil {
 		return nil, err
 	}
-	return &cofidectl_proto.ListTrustZonesResponse{TrustZones: resp}, nil
+	return &cofidectl_proto.ValidateResponse{}, nil
 }
 
-/*
-func (s *GRPCServer) CreateTrustZone(ctx context.Context, req *cofidectl_proto.CreateTrustZoneRequest) (*cofidectl_proto.CreateTrustZoneResponse, error) {
-	// TODO
-	return &cofidectl_proto.CreateTrustZoneResponse{}, nil
-
+func (s *GRPCServer) GetTrustZone(_ context.Context, req *cofidectl_proto.GetTrustZoneRequest) (*cofidectl_proto.GetTrustZoneResponse, error) {
+	trustZone, err := s.Impl.GetTrustZone(req.GetName())
+	if err != nil {
+		return nil, err
+	}
+	return &cofidectl_proto.GetTrustZoneResponse{TrustZone: trustZone}, nil
 }
 
-func (s *GRPCServer) CreateAttestationPolicy(ctx context.Context, req *cofidectl_proto.CreateAttestationPolicyRequest) (*cofidectl_proto.CreateAttestationPolicyResponse, error) {
-	// TODO
-	return &cofidectl_proto.CreateAttestationPolicyResponse{}, nil
+func (s *GRPCServer) ListTrustZones(_ context.Context, req *cofidectl_proto.ListTrustZonesRequest) (*cofidectl_proto.ListTrustZonesResponse, error) {
+	trustZones, err := s.Impl.ListTrustZones()
+	if err != nil {
+		return nil, err
+	}
+	return &cofidectl_proto.ListTrustZonesResponse{TrustZones: trustZones}, nil
 }
-*/
+
+func (s *GRPCServer) AddTrustZone(_ context.Context, req *cofidectl_proto.AddTrustZoneRequest) (*cofidectl_proto.AddTrustZoneResponse, error) {
+	trustZone, err := s.Impl.AddTrustZone(req.TrustZone)
+	if err != nil {
+		return nil, err
+	}
+	return &cofidectl_proto.AddTrustZoneResponse{TrustZone: trustZone}, nil
+}
+
+func (s *GRPCServer) UpdateTrustZone(_ context.Context, req *cofidectl_proto.UpdateTrustZoneRequest) (*cofidectl_proto.UpdateTrustZoneResponse, error) {
+	err := s.Impl.UpdateTrustZone(req.TrustZone)
+	if err != nil {
+		return nil, err
+	}
+	return &cofidectl_proto.UpdateTrustZoneResponse{}, nil
+}
+
+func (s *GRPCServer) AddAttestationPolicy(_ context.Context, req *cofidectl_proto.AddAttestationPolicyRequest) (*cofidectl_proto.AddAttestationPolicyResponse, error) {
+	policy, err := s.Impl.AddAttestationPolicy(req.Policy)
+	if err != nil {
+		return nil, err
+	}
+	return &cofidectl_proto.AddAttestationPolicyResponse{Policy: policy}, nil
+}
+
+func (s *GRPCServer) GetAttestationPolicy(_ context.Context, req *cofidectl_proto.GetAttestationPolicyRequest) (*cofidectl_proto.GetAttestationPolicyResponse, error) {
+	resp, err := s.Impl.GetAttestationPolicy(req.GetName())
+	if err != nil {
+		return nil, err
+	}
+	return &cofidectl_proto.GetAttestationPolicyResponse{Policy: resp}, nil
+}
+
+func (s *GRPCServer) ListAttestationPolicies(_ context.Context, req *cofidectl_proto.ListAttestationPoliciesRequest) (*cofidectl_proto.ListAttestationPoliciesResponse, error) {
+	policies, err := s.Impl.ListAttestationPolicies()
+	if err != nil {
+		return nil, err
+	}
+	return &cofidectl_proto.ListAttestationPoliciesResponse{Policies: policies}, nil
+}
+
+func (s *GRPCServer) AddAPBinding(_ context.Context, req *cofidectl_proto.AddAPBindingRequest) (*cofidectl_proto.AddAPBindingResponse, error) {
+	binding, err := s.Impl.AddAPBinding(req.Binding)
+	if err != nil {
+		return nil, err
+	}
+	return &cofidectl_proto.AddAPBindingResponse{Binding: binding}, nil
+}
+
+func (s *GRPCServer) DestroyAPBinding(_ context.Context, req *cofidectl_proto.DestroyAPBindingRequest) (*cofidectl_proto.DestroyAPBindingResponse, error) {
+	err := s.Impl.DestroyAPBinding(req.Binding)
+	if err != nil {
+		return nil, err
+	}
+	return &cofidectl_proto.DestroyAPBindingResponse{}, nil
+}
+
+func (s *GRPCServer) AddFederation(_ context.Context, req *cofidectl_proto.AddFederationRequest) (*cofidectl_proto.AddFederationResponse, error) {
+	federation, err := s.Impl.AddFederation(req.Federation)
+	if err != nil {
+		return nil, err
+	}
+	return &cofidectl_proto.AddFederationResponse{Federation: federation}, nil
+}
+
+func (s *GRPCServer) ListFederations(_ context.Context, req *cofidectl_proto.ListFederationsRequest) (*cofidectl_proto.ListFederationsResponse, error) {
+	federations, err := s.Impl.ListFederations()
+	if err != nil {
+		return nil, err
+	}
+	return &cofidectl_proto.ListFederationsResponse{Federations: federations}, nil
+}
+
+func (s *GRPCServer) ListFederationsByTrustZone(_ context.Context, req *cofidectl_proto.ListFederationsByTrustZoneRequest) (*cofidectl_proto.ListFederationsByTrustZoneResponse, error) {
+	federations, err := s.Impl.ListFederationsByTrustZone(req.GetTrustZoneName())
+	if err != nil {
+		return nil, err
+	}
+	return &cofidectl_proto.ListFederationsByTrustZoneResponse{Federations: federations}, nil
+}


### PR DESCRIPTION
Implements all data source gRPC service RPCs for the client and service.

Adds a type check to ensure that the client implements the DataSource
interface.

Fixes: #59
Depends-On: https://github.com/cofide/cofide-api-sdk/pull/9
