### PR TITLE
feat: Update `GenerateValues` method to support provisioning plugin values injection

### DIFF
--- a/cmd/cofidectl/cmd/trustzone/helm/helm.go
+++ b/cmd/cofidectl/cmd/trustzone/helm/helm.go
@@ -107,7 +107,7 @@ func (c *HelmCommand) overrideValues(ds plugin.DataSource, tzName string, values
 	}
 
 	// Check that the values are acceptable.
-	generator := helm.NewHelmValuesGenerator(trustZone, ds)
+	generator := helm.NewHelmValuesGenerator(trustZone, ds, nil)
 	if _, err = generator.GenerateValues(); err != nil {
 		return err
 	}
@@ -183,7 +183,7 @@ func (c *HelmCommand) getValues(ds plugin.DataSource, tzName string) (map[string
 		return nil, err
 	}
 
-	generator := helm.NewHelmValuesGenerator(trustZone, ds)
+	generator := helm.NewHelmValuesGenerator(trustZone, ds, nil)
 	values, err := generator.GenerateValues()
 	if err != nil {
 		return nil, err

--- a/cmd/cofidectl/cmd/up.go
+++ b/cmd/cofidectl/cmd/up.go
@@ -13,8 +13,8 @@ import (
 	"github.com/cofide/cofidectl/pkg/provider"
 	"github.com/cofide/cofidectl/pkg/provider/helm"
 
-	cmdcontext "github.com/cofide/cofidectl/pkg/cmd/context"
 	"github.com/cofide/cofidectl/cmd/cofidectl/cmd/statusspinner"
+	cmdcontext "github.com/cofide/cofidectl/pkg/cmd/context"
 	cofidectl_plugin "github.com/cofide/cofidectl/pkg/plugin"
 	"github.com/spf13/cobra"
 )
@@ -97,7 +97,7 @@ func addSPIRERepository(ctx context.Context) error {
 
 func installSPIREStack(ctx context.Context, source cofidectl_plugin.DataSource, trustZones []*trust_zone_proto.TrustZone) error {
 	for _, trustZone := range trustZones {
-		generator := helm.NewHelmValuesGenerator(trustZone, source)
+		generator := helm.NewHelmValuesGenerator(trustZone, source, nil)
 		spireValues, err := generator.GenerateValues()
 		if err != nil {
 			return err
@@ -173,7 +173,7 @@ func getBundleAndEndpoint(ctx context.Context, statusCh chan<- provider.Provider
 
 func applyPostInstallHelmConfig(ctx context.Context, source cofidectl_plugin.DataSource, trustZones []*trust_zone_proto.TrustZone) error {
 	for _, trustZone := range trustZones {
-		generator := helm.NewHelmValuesGenerator(trustZone, source)
+		generator := helm.NewHelmValuesGenerator(trustZone, source, nil)
 
 		spireValues, err := generator.GenerateValues()
 		if err != nil {

--- a/internal/pkg/attestationpolicy/attestationpolicy.go
+++ b/internal/pkg/attestationpolicy/attestationpolicy.go
@@ -65,22 +65,22 @@ func (ap *AttestationPolicy) GetHelmConfig(source cofidectl_plugin.DataSource, b
 	return clusterSPIFFEID, nil
 }
 
-func getAPLabelSelectorHelmConfig(selector *attestation_policy_proto.APLabelSelector) map[string]interface{} {
+func getAPLabelSelectorHelmConfig(selector *attestation_policy_proto.APLabelSelector) map[string]any {
 	if len(selector.MatchLabels) == 0 && len(selector.MatchExpressions) == 0 {
 		return nil
 	}
 
-	var matchExpressions = []map[string]interface{}{}
+	var matchExpressions = []map[string]any{}
 
 	for _, me := range selector.MatchExpressions {
-		matchExpressions = append(matchExpressions, map[string]interface{}{
+		matchExpressions = append(matchExpressions, map[string]any{
 			"key":      me.GetKey(),
 			"operator": me.GetOperator(),
 			"values":   me.GetValues(),
 		})
 	}
 
-	return map[string]interface{}{
+	return map[string]any{
 		"matchLabels":      selector.MatchLabels,
 		"matchExpressions": matchExpressions,
 	}

--- a/internal/pkg/attestationpolicy/attestationpolicy.go
+++ b/internal/pkg/attestationpolicy/attestationpolicy.go
@@ -70,8 +70,18 @@ func getAPLabelSelectorHelmConfig(selector *attestation_policy_proto.APLabelSele
 		return nil
 	}
 
+	var matchExpressions = []map[string]interface{}{}
+
+	for _, me := range selector.MatchExpressions {
+		matchExpressions = append(matchExpressions, map[string]interface{}{
+			"key":      me.GetKey(),
+			"operator": me.GetOperator(),
+			"values":   me.GetValues(),
+		})
+	}
+
 	return map[string]interface{}{
 		"matchLabels":      selector.MatchLabels,
-		"matchExpressions": selector.MatchExpressions,
+		"matchExpressions": matchExpressions,
 	}
 }

--- a/pkg/provider/helm/values.go
+++ b/pkg/provider/helm/values.go
@@ -171,9 +171,12 @@ func (g *HelmValuesGenerator) GenerateValues() (map[string]any, error) {
 			}
 
 			if tz.GetBundleEndpointUrl() != "" {
-				spireServer["federation"] = map[string]any{
-					"enabled": true,
+				fedMap, err := getOrCreateNestedMap(spireServer, "federation")
+				if err != nil {
+					return nil, fmt.Errorf("failed to get federation map from spireServer: %w", err)
 				}
+
+				fedMap["enabled"] = true
 
 				cftd, err := getOrCreateNestedMap(identities, "clusterFederatedTrustDomains")
 				if err != nil {

--- a/pkg/provider/helm/values.go
+++ b/pkg/provider/helm/values.go
@@ -21,18 +21,17 @@ type HelmValuesGenerator struct {
 }
 
 type globalValues struct {
+	deleteHooks                   bool
+	installAndUpgradeHooksEnabled bool
 	spireClusterName              string
 	spireCreateRecommendations    bool
 	spireTrustDomain              string
-	installAndUpgradeHooksEnabled bool
-	deleteHooks                   bool
 }
 
 type spireAgentValues struct {
-	fullnameOverride string
-	logLevel         string
-
 	agentConfig        trustprovider.TrustProviderAgentConfig
+	fullnameOverride   string
+	logLevel           string
 	spireServerAddress string
 }
 

--- a/pkg/provider/helm/values.go
+++ b/pkg/provider/helm/values.go
@@ -426,26 +426,20 @@ func getOrCreateNestedMap(m map[string]any, key string) (map[string]any, error) 
 
 // mergeMaps merges the source map into the destination map, returning a new merged map.
 func mergeMaps(dest, src map[string]any) map[string]any {
-	merged := make(map[string]any)
-
-	for key, value := range dest {
-		merged[key] = value
-	}
-
 	for key, value := range src {
 		if srcMap, isSrcMap := value.(map[string]any); isSrcMap {
-			if destMap, isDestMap := merged[key].(map[string]any); isDestMap {
-				merged[key] = mergeMaps(destMap, srcMap)
+			if destMap, isDestMap := dest[key].(map[string]any); isDestMap {
+				dest[key] = mergeMaps(destMap, srcMap)
 			} else {
-				merged[key] = srcMap
+				dest[key] = srcMap
 			}
 		} else {
 			// Always overwrite existing keys.
-			merged[key] = value
+			dest[key] = value
 		}
 	}
 
-	return merged
+	return dest
 }
 
 // shallowMerge flattens a slice of maps into a single map.

--- a/pkg/provider/helm/values.go
+++ b/pkg/provider/helm/values.go
@@ -19,12 +19,14 @@ import (
 type HelmValuesGenerator struct {
 	source    cofidectl_plugin.DataSource
 	trustZone *trust_zone_proto.TrustZone
+	values    map[string]interface{}
 }
 
-func NewHelmValuesGenerator(trustZone *trust_zone_proto.TrustZone, source cofidectl_plugin.DataSource) *HelmValuesGenerator {
+func NewHelmValuesGenerator(trustZone *trust_zone_proto.TrustZone, source cofidectl_plugin.DataSource, values map[string]interface{}) *HelmValuesGenerator {
 	return &HelmValuesGenerator{
 		trustZone: trustZone,
 		source:    source,
+		values:    values,
 	}
 }
 

--- a/pkg/provider/helm/values_test.go
+++ b/pkg/provider/helm/values_test.go
@@ -605,6 +605,66 @@ func TestMergeMaps(t *testing.T) {
 			},
 		},
 		{
+			name: "valid src and valid dest, additional nesting, retaining existing",
+			src: map[string]any{
+				"spire-server": map[string]any{
+					"controllerManager": map[string]any{
+						"identities": map[string]any{
+							"clusterFederatedTrustDomains": map[string]any{
+								"cofide": map[string]any{
+									"bundleEndpointProfile": map[string]any{
+										"type": "https_web",
+									},
+									"bundleEndpointURL": "https://td1/connect/bundle",
+									"trustDomain":       "td1",
+								},
+							},
+						},
+					},
+				},
+			},
+			dest: map[string]any{
+				"spire-server": map[string]any{
+					"caKeyType": "rsa-2048",
+					"controllerManager": map[string]any{
+						"enabled": true,
+						"identities": map[string]any{
+							"clusterSPIFFEIDs": map[string]any{
+								"default": Values{
+									"enabled": true,
+								},
+							},
+						},
+					},
+				},
+			},
+			overwriteExistingKeys: true,
+			want: map[string]any{
+				"spire-server": map[string]any{
+					"caKeyType": "rsa-2048",
+					"controllerManager": map[string]any{
+						"enabled": true,
+						"identities": map[string]any{
+							"clusterSPIFFEIDs": map[string]any{
+								"default": Values{
+									"enabled": true,
+								},
+							},
+							"clusterFederatedTrustDomains": map[string]any{
+								"cofide": map[string]any{
+									"bundleEndpointProfile": map[string]any{
+										"type": "https_web",
+									},
+									"bundleEndpointURL": "https://td1/connect/bundle",
+									"trustDomain":       "td1",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
 			name: "valid src and valid dest, additional nesting, with overwrites",
 			src: map[string]any{
 				"spire-server": map[string]any{

--- a/pkg/provider/helm/values_test.go
+++ b/pkg/provider/helm/values_test.go
@@ -539,10 +539,12 @@ func TestGetOrCreateNestedMap(t *testing.T) {
 
 func TestMergeMaps(t *testing.T) {
 	tests := []struct {
-		name string
-		src  map[string]any
-		dest map[string]any
-		want map[string]any
+		name      string
+		src       map[string]any
+		dest      map[string]any
+		want      map[string]any
+		wantErr   bool
+		errString string
 	}{
 		{
 			name: "valid src and valid dest",
@@ -732,10 +734,29 @@ func TestMergeMaps(t *testing.T) {
 				},
 			},
 		},
+		{
+			name:      "nil src and valid dest",
+			src:       nil,
+			dest:      map[string]any{"foo": "bar"},
+			wantErr:   true,
+			errString: "source map is nil",
+		},
+		{
+			name:      "valid src and nil dest",
+			src:       map[string]any{"foo": "bar"},
+			dest:      nil,
+			wantErr:   true,
+			errString: "destination map is nil",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			resp := mergeMaps(tt.dest, tt.src)
+			resp, err := mergeMaps(tt.dest, tt.src)
+			if tt.wantErr {
+				assert.Equal(t, tt.errString, err.Error())
+				return
+			}
+
 			assert.Equal(t, tt.want, resp)
 		})
 	}

--- a/pkg/provider/helm/values_test.go
+++ b/pkg/provider/helm/values_test.go
@@ -578,6 +578,36 @@ func TestMergeMaps(t *testing.T) {
 			},
 		},
 		{
+			name: "valid src and valid dest, src and dest types differ",
+			src: map[string]any{
+				"fizz": "buzz",
+			},
+			dest: map[string]any{
+				"fizz": map[string]any{
+					"fizz nested": "buzz",
+				},
+			},
+			want: map[string]any{
+				"fizz": "buzz",
+			},
+		},
+		{
+			name: "valid src and valid dest, dest and src types differ",
+			src: map[string]any{
+				"fizz": map[string]any{
+					"fizz nested": "buzz",
+				},
+			},
+			dest: map[string]any{
+				"fizz": "buzz",
+			},
+			want: map[string]any{
+				"fizz": map[string]any{
+					"fizz nested": "buzz",
+				},
+			},
+		},
+		{
 			name: "valid src and valid dest, nested",
 			src: map[string]any{
 				"global": map[string]any{

--- a/pkg/provider/helm/values_test.go
+++ b/pkg/provider/helm/values_test.go
@@ -234,6 +234,7 @@ func TestHelmValuesGenerator_GenerateValues_success(t *testing.T) {
 				trustZone: tt.trustZone,
 				values:    nil,
 			}
+
 			got, err := g.GenerateValues()
 			require.Nil(t, err, err)
 			assert.Equal(t, tt.want, got)
@@ -373,6 +374,7 @@ func TestHelmValuesGenerator_GenerateValues_AdditionalValues(t *testing.T) {
 				trustZone: tt.trustZone,
 				values:    tt.values,
 			}
+
 			got, err := g.GenerateValues()
 			require.Nil(t, err, err)
 			assert.Equal(t, tt.want, got)
@@ -485,168 +487,6 @@ func TestGetNestedMap(t *testing.T) {
 			if tt.exists {
 				assert.Equal(t, tt.want, resp)
 			}
-		})
-	}
-}
-
-func TestMergeValues(t *testing.T) {
-	tests := []struct {
-		name                  string
-		dest                  map[string]any
-		values                map[string]any
-		overwriteExistingKeys bool
-		want                  map[string]any
-	}{
-		{
-			name: "valid values and valid dest, no overwrites",
-			dest: map[string]any{
-				"foo": "bar",
-			},
-			values: map[string]any{
-				"fizz": "buzz",
-			},
-			overwriteExistingKeys: false,
-			want: map[string]any{
-				"foo":  "bar",
-				"fizz": "buzz",
-			},
-		},
-		{
-			name: "valid dest and empty values, no overwrites",
-			dest: map[string]any{
-				"foo": "bar",
-			},
-			values:                map[string]any{},
-			overwriteExistingKeys: false,
-			want: map[string]any{
-				"foo": "bar",
-			},
-		},
-		{
-			name: "empty dest and valid values, no overwrites",
-			dest: map[string]any{},
-			values: map[string]any{
-				"fizz": "buzz",
-			},
-			overwriteExistingKeys: false,
-			want: map[string]any{
-				"fizz": "buzz",
-			},
-		},
-		{
-			name: "valid dest and valid values, nested, no overwrites",
-			dest: map[string]any{
-				"global": map[string]any{
-					"spire": map[string]any{
-						"clusterName": "local1-old",
-					},
-				},
-			},
-			values: map[string]any{
-				"global": map[string]any{
-					"spire": map[string]any{
-						"clusterName": "local1-new",
-					},
-					"trustDomain": "td1",
-				},
-			},
-			overwriteExistingKeys: false,
-			want: map[string]any{
-				"global": map[string]any{
-					"spire": map[string]any{
-						"clusterName": "local1-old",
-					},
-					"trustDomain": "td1",
-				},
-			},
-		},
-		{
-			name: "valid dest and valid values, with overwrites",
-			dest: map[string]any{
-				"foo":   "bar",
-				"hello": "world",
-			},
-			values: map[string]any{
-				"foo": "baz",
-			},
-			overwriteExistingKeys: true,
-			want: map[string]any{
-				"foo":   "baz",
-				"hello": "world",
-			},
-		},
-		{
-			name: "valid dest and valid src, additional nesting, with overwrites",
-			dest: map[string]any{
-				"spire-server": map[string]any{
-					"caKeyType": "rsa-2048",
-					"controllerManager": map[string]any{
-						"enabled": true,
-						"identities": map[string]any{
-							"clusterSPIFFEIDs": map[string]any{
-								"default": Values{
-									"enabled": false,
-								},
-							},
-							"clusterFederatedTrustDomains": map[string]any{
-								"cofide": map[string]any{
-									"bundleEndpointProfile": map[string]any{
-										"type": "https_web",
-									},
-									"bundleEndpointURL": "https://td1/connect/bundle",
-									"trustDomain":       "td1",
-								},
-							},
-						},
-					},
-				},
-			},
-			values: map[string]any{
-				"spire-server": map[string]any{
-					"caKeyType": "rsa-2048",
-					"controllerManager": map[string]any{
-						"enabled": true,
-						"identities": map[string]any{
-							"clusterSPIFFEIDs": map[string]any{
-								"default": Values{
-									"enabled": true,
-								},
-							},
-						},
-					},
-				},
-			},
-			overwriteExistingKeys: true,
-			want: map[string]any{
-				"spire-server": map[string]any{
-					"caKeyType": "rsa-2048",
-					"controllerManager": map[string]any{
-						"enabled": true,
-						"identities": map[string]any{
-							"clusterSPIFFEIDs": map[string]any{
-								"default": Values{
-									"enabled": true,
-								},
-							},
-							"clusterFederatedTrustDomains": map[string]any{
-								"cofide": map[string]any{
-									"bundleEndpointProfile": map[string]any{
-										"type": "https_web",
-									},
-									"bundleEndpointURL": "https://td1/connect/bundle",
-									"trustDomain":       "td1",
-								},
-							},
-						},
-					},
-				},
-			},
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			mergeValues(tt.dest, tt.values, tt.overwriteExistingKeys)
-			assert.Equal(t, tt.want, tt.dest)
 		})
 	}
 }

--- a/pkg/provider/helm/values_test.go
+++ b/pkg/provider/helm/values_test.go
@@ -746,6 +746,59 @@ func TestGlobalValues_GenerateValues(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			name: "valid global values, empty jwtIssuer value",
+			input: globalValues{
+				spireClusterName: "local1",
+				spireTrustDomain: "td1",
+				spireJwtIssuer:   "",
+			},
+			want: map[string]any{
+				"global": map[string]any{
+					"spire": map[string]any{
+						"clusterName": "local1",
+						"recommendations": map[string]any{
+							"create": false,
+						},
+						"trustDomain": "td1",
+					},
+					"installAndUpgradeHooks": map[string]any{
+						"enabled": false,
+					},
+					"deleteHooks": map[string]any{
+						"enabled": false,
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "valid global values, populated jwtIssuer value",
+			input: globalValues{
+				spireClusterName: "local1",
+				spireTrustDomain: "td1",
+				spireJwtIssuer:   "https://tz1.example.com",
+			},
+			want: map[string]any{
+				"global": map[string]any{
+					"spire": map[string]any{
+						"clusterName": "local1",
+						"jwtIssuer":   "https://tz1.example.com",
+						"recommendations": map[string]any{
+							"create": false,
+						},
+						"trustDomain": "td1",
+					},
+					"installAndUpgradeHooks": map[string]any{
+						"enabled": false,
+					},
+					"deleteHooks": map[string]any{
+						"enabled": false,
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
 			name: "invalid global values, missing spireTrustDomain value",
 			input: globalValues{
 				spireClusterName: "local1",

--- a/pkg/provider/helm/values_test.go
+++ b/pkg/provider/helm/values_test.go
@@ -18,7 +18,6 @@ import (
 )
 
 type Values = map[string]any
-type ValueList = []any
 
 func TestHelmValuesGenerator_GenerateValues_success(t *testing.T) {
 	tests := []struct {
@@ -470,12 +469,7 @@ func TestGetNestedMap(t *testing.T) {
 					"caTTL":     "12h",
 				},
 			},
-			key: "global",
-			want: map[string]any{
-				"spire": map[string]any{
-					"clusterName": "local1",
-				},
-			},
+			key:    "global",
 			exists: false,
 		},
 	}
@@ -493,50 +487,46 @@ func TestGetNestedMap(t *testing.T) {
 
 func TestMergeMaps(t *testing.T) {
 	tests := []struct {
-		name                  string
-		src                   map[string]any
-		dest                  map[string]any
-		overwriteExistingKeys bool
-		want                  map[string]any
+		name string
+		src  map[string]any
+		dest map[string]any
+		want map[string]any
 	}{
 		{
-			name: "valid src and valid dest, no overwrites",
+			name: "valid src and valid dest",
 			src: map[string]any{
 				"foo": "bar",
 			},
 			dest: map[string]any{
 				"fizz": "buzz",
 			},
-			overwriteExistingKeys: false,
 			want: map[string]any{
 				"foo":  "bar",
 				"fizz": "buzz",
 			},
 		},
 		{
-			name: "valid src and empty dest, no overwrites",
+			name: "valid src and empty dest",
 			src: map[string]any{
 				"foo": "bar",
 			},
-			dest:                  map[string]any{},
-			overwriteExistingKeys: false,
+			dest: map[string]any{},
 			want: map[string]any{
 				"foo": "bar",
 			},
 		},
 		{
-			name: "empty src and valid dest, no overwrites",
+			name: "empty src and valid dest",
 			src:  map[string]any{},
 			dest: map[string]any{
 				"fizz": "buzz",
 			},
-			overwriteExistingKeys: false,
 			want: map[string]any{
 				"fizz": "buzz",
 			},
 		},
 		{
-			name: "valid src and valid dest, nested, no overwrites",
+			name: "valid src and valid dest, nested",
 			src: map[string]any{
 				"global": map[string]any{
 					"spire": map[string]any{
@@ -552,18 +542,17 @@ func TestMergeMaps(t *testing.T) {
 					"trustDomain": "td1",
 				},
 			},
-			overwriteExistingKeys: false,
 			want: map[string]any{
 				"global": map[string]any{
 					"spire": map[string]any{
-						"clusterName": "local1",
+						"clusterName": "local1-new",
 					},
 					"trustDomain": "td1",
 				},
 			},
 		},
 		{
-			name: "valid src and valid dest, with overwrites",
+			name: "valid src and valid dest, with existing key",
 			src: map[string]any{
 				"foo":   "bar",
 				"hello": "world",
@@ -571,14 +560,13 @@ func TestMergeMaps(t *testing.T) {
 			dest: map[string]any{
 				"foo": "baz",
 			},
-			overwriteExistingKeys: true,
 			want: map[string]any{
 				"foo":   "bar",
 				"hello": "world",
 			},
 		},
 		{
-			name: "valid src and valid dest, nested, with overwrites",
+			name: "valid src and valid dest, nested, with existing key",
 			src: map[string]any{
 				"global": map[string]any{
 					"spire": map[string]any{
@@ -594,7 +582,6 @@ func TestMergeMaps(t *testing.T) {
 					"trustDomain": "td1",
 				},
 			},
-			overwriteExistingKeys: true,
 			want: map[string]any{
 				"global": map[string]any{
 					"spire": map[string]any{
@@ -605,7 +592,7 @@ func TestMergeMaps(t *testing.T) {
 			},
 		},
 		{
-			name: "valid src and valid dest, additional nesting, retaining existing",
+			name: "valid src and valid dest, additional nesting, existing key",
 			src: map[string]any{
 				"spire-server": map[string]any{
 					"controllerManager": map[string]any{
@@ -638,7 +625,6 @@ func TestMergeMaps(t *testing.T) {
 					},
 				},
 			},
-			overwriteExistingKeys: true,
 			want: map[string]any{
 				"spire-server": map[string]any{
 					"caKeyType": "rsa-2048",
@@ -648,73 +634,6 @@ func TestMergeMaps(t *testing.T) {
 							"clusterSPIFFEIDs": map[string]any{
 								"default": Values{
 									"enabled": true,
-								},
-							},
-							"clusterFederatedTrustDomains": map[string]any{
-								"cofide": map[string]any{
-									"bundleEndpointProfile": map[string]any{
-										"type": "https_web",
-									},
-									"bundleEndpointURL": "https://td1/connect/bundle",
-									"trustDomain":       "td1",
-								},
-							},
-						},
-					},
-				},
-			},
-		},
-		{
-			name: "valid src and valid dest, additional nesting, with overwrites",
-			src: map[string]any{
-				"spire-server": map[string]any{
-					"caKeyType": "rsa-2048",
-					"controllerManager": map[string]any{
-						"enabled": true,
-						"identities": map[string]any{
-							"clusterSPIFFEIDs": map[string]any{
-								"default": Values{
-									"enabled": false,
-								},
-							},
-							"clusterFederatedTrustDomains": map[string]any{
-								"cofide": map[string]any{
-									"bundleEndpointProfile": map[string]any{
-										"type": "https_web",
-									},
-									"bundleEndpointURL": "https://td1/connect/bundle",
-									"trustDomain":       "td1",
-								},
-							},
-						},
-					},
-				},
-			},
-			dest: map[string]any{
-				"spire-server": map[string]any{
-					"caKeyType": "rsa-2048",
-					"controllerManager": map[string]any{
-						"enabled": true,
-						"identities": map[string]any{
-							"clusterSPIFFEIDs": map[string]any{
-								"default": Values{
-									"enabled": true,
-								},
-							},
-						},
-					},
-				},
-			},
-			overwriteExistingKeys: true,
-			want: map[string]any{
-				"spire-server": map[string]any{
-					"caKeyType": "rsa-2048",
-					"controllerManager": map[string]any{
-						"enabled": true,
-						"identities": map[string]any{
-							"clusterSPIFFEIDs": map[string]any{
-								"default": Values{
-									"enabled": false,
 								},
 							},
 							"clusterFederatedTrustDomains": map[string]any{
@@ -734,13 +653,13 @@ func TestMergeMaps(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			resp := mergeMaps(tt.src, tt.dest, tt.overwriteExistingKeys)
+			resp := mergeMaps(tt.dest, tt.src)
 			assert.Equal(t, tt.want, resp)
 		})
 	}
 }
 
-func TestFlattenMaps(t *testing.T) {
+func TestShallowMerge(t *testing.T) {
 	tests := []struct {
 		name string
 		maps []map[string]any
@@ -787,7 +706,7 @@ func TestFlattenMaps(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			resp := flattenMaps(tt.maps)
+			resp := shallowMerge(tt.maps)
 			assert.Equal(t, tt.want, resp)
 		})
 	}

--- a/pkg/provider/helm/values_test.go
+++ b/pkg/provider/helm/values_test.go
@@ -506,17 +506,6 @@ func TestGetOrCreateNestedMap(t *testing.T) {
 				"fullnameOverride": "spire-server",
 			},
 		},
-		{
-			name: "map doesn't exist, valid key",
-			values: map[string]any{
-				"spire-server": map[string]any{
-					"caKeyType": "rsa-2048",
-					"caTTL":     "12h",
-				},
-			},
-			key:  "global",
-			want: map[string]any{},
-		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -757,6 +746,7 @@ func TestMergeMaps(t *testing.T) {
 				return
 			}
 
+			assert.Nil(t, err)
 			assert.Equal(t, tt.want, resp)
 		})
 	}
@@ -919,6 +909,7 @@ func TestGlobalValues_GenerateValues(t *testing.T) {
 				return
 			}
 
+			assert.Nil(t, err)
 			assert.Equal(t, tt.want, resp)
 		})
 	}
@@ -1051,6 +1042,7 @@ func TestSpireAgentValues_GenerateValues(t *testing.T) {
 				return
 			}
 
+			assert.Nil(t, err)
 			assert.Equal(t, tt.want, resp)
 		})
 	}
@@ -1167,6 +1159,7 @@ func TestSpireServerValues_GenerateValues(t *testing.T) {
 				return
 			}
 
+			assert.Nil(t, err)
 			assert.Equal(t, tt.want, resp)
 		})
 	}
@@ -1199,6 +1192,7 @@ func TestSpiffeOIDCDiscoveryProviderValues_GenerateValues(t *testing.T) {
 				return
 			}
 
+			assert.Nil(t, err)
 			assert.Equal(t, tt.want, resp)
 		})
 	}
@@ -1231,6 +1225,7 @@ func TestSpiffeCSIDriverValues_GenerateValues(t *testing.T) {
 				return
 			}
 
+			assert.Nil(t, err)
 			assert.Equal(t, tt.want, resp)
 		})
 	}

--- a/pkg/provider/helm/values_test.go
+++ b/pkg/provider/helm/values_test.go
@@ -232,6 +232,7 @@ func TestHelmValuesGenerator_GenerateValues_success(t *testing.T) {
 			g := &HelmValuesGenerator{
 				source:    source,
 				trustZone: tt.trustZone,
+				values:    nil,
 			}
 			got, err := g.GenerateValues()
 			require.Nil(t, err, err)
@@ -305,6 +306,7 @@ func TestHelmValuesGenerator_GenerateValues_failure(t *testing.T) {
 			g := &HelmValuesGenerator{
 				source:    source,
 				trustZone: tt.trustZone,
+				values:    nil,
 			}
 			_, err := g.GenerateValues()
 			require.Error(t, err)


### PR DESCRIPTION
### Summary
- This PR updates the existing `HelmValuesGenerator` [GenerateValues](https://github.com/cofide/cofidectl/blob/b0ac6d298b9468d6b3189e12c1828abbb3530cf6/pkg/provider/helm/values.go#L31) method to support merging in a set of values from an additional source, beyond user supplied values (as added in #5), as required by #57.
- This PR decomposes the `GenerateValues` method, uses native Go types with a merge function (instead of CUE) and adds additional test coverage.