### PR TITLE
Fix Helm warnings seen in cofidectl up

### DIFF
--- a/internal/pkg/attestationpolicy/attestationpolicy.go
+++ b/internal/pkg/attestationpolicy/attestationpolicy.go
@@ -70,8 +70,12 @@ func getAPLabelSelectorHelmConfig(selector *attestation_policy_proto.APLabelSele
 		return nil
 	}
 
-	var matchExpressions = []map[string]any{}
+	matchLabels := map[string]any{}
+	for k, v := range selector.MatchLabels {
+		matchLabels[k] = v
+	}
 
+	matchExpressions := []map[string]any{}
 	for _, me := range selector.MatchExpressions {
 		matchExpressions = append(matchExpressions, map[string]any{
 			"key":      me.GetKey(),
@@ -81,7 +85,7 @@ func getAPLabelSelectorHelmConfig(selector *attestation_policy_proto.APLabelSele
 	}
 
 	return map[string]any{
-		"matchLabels":      selector.MatchLabels,
+		"matchLabels":      matchLabels,
 		"matchExpressions": matchExpressions,
 	}
 }

--- a/pkg/provider/helm/values_test.go
+++ b/pkg/provider/helm/values_test.go
@@ -188,7 +188,7 @@ func TestHelmValuesGenerator_GenerateValues_success(t *testing.T) {
 									},
 									"namespaceSelector": Values{
 										"matchExpressions": []map[string]any{},
-										"matchLabels": map[string]string{
+										"matchLabels": map[string]any{
 											"kubernetes.io/metadata.name": "ns1",
 										},
 									},


### PR DESCRIPTION
After #62 merged we started seeing some warnings during cofidectl up.
This is due to a change in the type of the Helm values generated for
matchLabels in clusterSPIFFEIDs from map[string]any to
map[string]string.

This change reverts to map[string]any, which removes the warning.

Fixes: #65
