### PR TITLE
feat: Replace instances of `map[string]interface{}` to use the `any` alias

### DIFF
--- a/cmd/cofidectl/cmd/trustzone/helm/helm.go
+++ b/cmd/cofidectl/cmd/trustzone/helm/helm.go
@@ -95,7 +95,7 @@ func (c *HelmCommand) GetOverrideCommand() *cobra.Command {
 }
 
 // overrideValues overrides Helm values for a trust zone.
-func (c *HelmCommand) overrideValues(ds plugin.DataSource, tzName string, values map[string]interface{}) error {
+func (c *HelmCommand) overrideValues(ds plugin.DataSource, tzName string, values map[string]any) error {
 	trustZone, err := ds.GetTrustZone(tzName)
 	if err != nil {
 		return err
@@ -116,9 +116,9 @@ func (c *HelmCommand) overrideValues(ds plugin.DataSource, tzName string, values
 }
 
 // readValues reads values in YAML format from the specified reader.
-func readValues(reader io.Reader) (map[string]interface{}, error) {
+func readValues(reader io.Reader) (map[string]any, error) {
 	decoder := yaml.NewDecoder(reader)
-	var values map[string]interface{}
+	var values map[string]any
 	err := decoder.Decode(&values)
 	return values, err
 }
@@ -177,7 +177,7 @@ func (c *HelmCommand) GetValuesCommand() *cobra.Command {
 }
 
 // getValues returns the Helm values for a trust zone.
-func (c *HelmCommand) getValues(ds plugin.DataSource, tzName string) (map[string]interface{}, error) {
+func (c *HelmCommand) getValues(ds plugin.DataSource, tzName string) (map[string]any, error) {
 	trustZone, err := ds.GetTrustZone(tzName)
 	if err != nil {
 		return nil, err
@@ -192,7 +192,7 @@ func (c *HelmCommand) getValues(ds plugin.DataSource, tzName string) (map[string
 }
 
 // writeValues writes values in YAML format to the specified writer.
-func writeValues(values map[string]interface{}, writer io.Writer) error {
+func writeValues(values map[string]any, writer io.Writer) error {
 	encoder := yaml.NewEncoder(writer)
 	defer encoder.Close()
 	return encoder.Encode(values)

--- a/internal/pkg/attestationpolicy/attestationpolicy.go
+++ b/internal/pkg/attestationpolicy/attestationpolicy.go
@@ -28,8 +28,8 @@ func NewAttestationPolicy(attestationPolicy *attestation_policy_proto.Attestatio
 	}
 }
 
-func (ap *AttestationPolicy) GetHelmConfig(source cofidectl_plugin.DataSource, binding *ap_binding_proto.APBinding) (map[string]interface{}, error) {
-	var clusterSPIFFEID = make(map[string]interface{})
+func (ap *AttestationPolicy) GetHelmConfig(source cofidectl_plugin.DataSource, binding *ap_binding_proto.APBinding) (map[string]any, error) {
+	var clusterSPIFFEID = make(map[string]any)
 	switch policy := ap.AttestationPolicyProto.Policy.(type) {
 	case *attestation_policy_proto.AttestationPolicy_Kubernetes:
 		kubernetes := policy.Kubernetes

--- a/internal/pkg/federation/federation.go
+++ b/internal/pkg/federation/federation.go
@@ -19,10 +19,10 @@ func NewFederation(trustZone *trust_zone_proto.TrustZone) *Federation {
 	}
 }
 
-func (fed *Federation) GetHelmConfig() map[string]interface{} {
-	clusterFederatedTrustDomain := map[string]interface{}{
+func (fed *Federation) GetHelmConfig() map[string]any {
+	clusterFederatedTrustDomain := map[string]any{
 		"bundleEndpointURL": fed.destTrustZone.GetBundleEndpointUrl(),
-		"bundleEndpointProfile": map[string]interface{}{
+		"bundleEndpointProfile": map[string]any{
 			"type":             "https_spiffe",
 			"endpointSPIFFEID": fmt.Sprintf("spiffe://%s/spire/server", fed.destTrustZone.TrustDomain),
 		},

--- a/internal/pkg/test/fixtures/fixtures.go
+++ b/internal/pkg/test/fixtures/fixtures.go
@@ -41,15 +41,15 @@ var trustZoneFixtures map[string]*trust_zone_proto.TrustZone = map[string]*trust
 		},
 		JwtIssuer: StringPtr("https://tz1.example.com"),
 		ExtraHelmValues: func() *structpb.Struct {
-			ev := map[string]interface{}{
-				"global": map[string]interface{}{
-					"spire": map[string]interface{}{
-						"namespaces": map[string]interface{}{
+			ev := map[string]any{
+				"global": map[string]any{
+					"spire": map[string]any{
+						"namespaces": map[string]any{
 							"create": true,
 						},
 					},
 				},
-				"spire-server": map[string]interface{}{
+				"spire-server": map[string]any{
 					"logLevel": "INFO",
 				},
 			}

--- a/internal/pkg/trustprovider/trustprovider.go
+++ b/internal/pkg/trustprovider/trustprovider.go
@@ -38,7 +38,7 @@ func (tp *TrustProvider) GetValues() error {
 		tp.AgentConfig = TrustProviderAgentConfig{
 			WorkloadAttestor:        KubernetesTrustProvider,
 			WorkloadAttestorEnabled: true,
-			WorkloadAttestorConfig: map[string]interface{}{
+			WorkloadAttestorConfig: map[string]any{
 				"enabled":                     true,
 				"skipKubeletVerification":     true,
 				"disableContainerSelectors":   false,
@@ -51,7 +51,7 @@ func (tp *TrustProvider) GetValues() error {
 		tp.ServerConfig = TrustProviderServerConfig{
 			NodeAttestor:        kubernetesPsat,
 			NodeAttestorEnabled: true,
-			NodeAttestorConfig: map[string]interface{}{
+			NodeAttestorConfig: map[string]any{
 				"enabled":                 true,
 				"serviceAccountAllowList": []string{"spire:spire-agent"},
 				"audience":                []string{"spire-server"},
@@ -66,15 +66,15 @@ func (tp *TrustProvider) GetValues() error {
 }
 
 type TrustProviderAgentConfig struct {
-	WorkloadAttestor        string                 `yaml:"workloadAttestor"`
-	WorkloadAttestorEnabled bool                   `yaml:"workloadAttestorEnabled"`
-	WorkloadAttestorConfig  map[string]interface{} `yaml:"workloadAttestorConfig"`
-	NodeAttestor            string                 `yaml:"nodeAttestor"`
-	NodeAttestorEnabled     bool                   `yaml:"nodeAttestorEnabled"`
+	WorkloadAttestor        string         `yaml:"workloadAttestor"`
+	WorkloadAttestorEnabled bool           `yaml:"workloadAttestorEnabled"`
+	WorkloadAttestorConfig  map[string]any `yaml:"workloadAttestorConfig"`
+	NodeAttestor            string         `yaml:"nodeAttestor"`
+	NodeAttestorEnabled     bool           `yaml:"nodeAttestorEnabled"`
 }
 
 type TrustProviderServerConfig struct {
-	NodeAttestor        string                 `yaml:"nodeAttestor"`
-	NodeAttestorEnabled bool                   `yaml:"nodeAttestorEnabled"`
-	NodeAttestorConfig  map[string]interface{} `yaml:"nodeAttestorConfig"`
+	NodeAttestor        string         `yaml:"nodeAttestor"`
+	NodeAttestorEnabled bool           `yaml:"nodeAttestorEnabled"`
+	NodeAttestorConfig  map[string]any `yaml:"nodeAttestorConfig"`
 }

--- a/pkg/plugin/provision/spirehelm/spirehelm.go
+++ b/pkg/plugin/provision/spirehelm/spirehelm.go
@@ -79,7 +79,7 @@ func (h *SpireHelm) TearDown(ctx context.Context, ds plugin.DataSource) error {
 }
 
 func addSPIRERepository(ctx context.Context) error {
-	emptyValues := map[string]interface{}{}
+	emptyValues := map[string]any{}
 	prov, err := helm.NewHelmSPIREProvider(ctx, nil, emptyValues, emptyValues)
 	if err != nil {
 		return err
@@ -101,7 +101,7 @@ func installSPIREStack(ctx context.Context, source plugin.DataSource, trustZones
 			return err
 		}
 
-		spireCRDsValues := map[string]interface{}{}
+		spireCRDsValues := map[string]any{}
 		prov, err := helm.NewHelmSPIREProvider(ctx, trustZone, spireValues, spireCRDsValues)
 		if err != nil {
 			return err
@@ -178,7 +178,7 @@ func applyPostInstallHelmConfig(ctx context.Context, source plugin.DataSource, t
 			return err
 		}
 
-		spireCRDsValues := map[string]interface{}{}
+		spireCRDsValues := map[string]any{}
 
 		prov, err := helm.NewHelmSPIREProvider(ctx, trustZone, spireValues, spireCRDsValues)
 		if err != nil {

--- a/pkg/provider/helm/helm.go
+++ b/pkg/provider/helm/helm.go
@@ -45,12 +45,12 @@ type HelmSPIREProvider struct {
 	cfg              *action.Configuration
 	SPIREVersion     string
 	SPIRECRDsVersion string
-	spireValues      map[string]interface{}
-	spireCRDsValues  map[string]interface{}
+	spireValues      map[string]any
+	spireCRDsValues  map[string]any
 	trustZone        *trust_zone_proto.TrustZone
 }
 
-func NewHelmSPIREProvider(ctx context.Context, trustZone *trust_zone_proto.TrustZone, spireValues, spireCRDsValues map[string]interface{}) (*HelmSPIREProvider, error) {
+func NewHelmSPIREProvider(ctx context.Context, trustZone *trust_zone_proto.TrustZone, spireValues, spireCRDsValues map[string]any) (*HelmSPIREProvider, error) {
 	settings := cli.New()
 	settings.KubeContext = trustZone.GetKubernetesContext()
 
@@ -316,7 +316,7 @@ func (h *HelmSPIREProvider) installSPIRECRDs() (*release.Release, error) {
 	return installChart(h.ctx, h.cfg, client, SPIRECRDsChartName, h.settings, h.spireCRDsValues)
 }
 
-func installChart(ctx context.Context, cfg *action.Configuration, client *action.Install, chartName string, settings *cli.EnvSettings, values map[string]interface{}) (*release.Release, error) {
+func installChart(ctx context.Context, cfg *action.Configuration, client *action.Install, chartName string, settings *cli.EnvSettings, values map[string]any) (*release.Release, error) {
 	alreadyInstalled, err := checkIfAlreadyInstalled(cfg, chartName)
 	if err != nil {
 		return nil, fmt.Errorf("cannot determine chart installation status: %s", err)
@@ -356,7 +356,7 @@ func (h *HelmSPIREProvider) upgradeSPIRE() (*release.Release, error) {
 	return upgradeChart(h.ctx, h.cfg, client, SPIREChartName, h.settings, h.spireValues)
 }
 
-func upgradeChart(ctx context.Context, cfg *action.Configuration, client *action.Upgrade, chartName string, settings *cli.EnvSettings, values map[string]interface{}) (*release.Release, error) {
+func upgradeChart(ctx context.Context, cfg *action.Configuration, client *action.Upgrade, chartName string, settings *cli.EnvSettings, values map[string]any) (*release.Release, error) {
 	alreadyInstalled, err := checkIfAlreadyInstalled(cfg, chartName)
 	if err != nil {
 		return nil, fmt.Errorf("cannot determine chart installation status: %s", err)

--- a/pkg/provider/helm/helm_test.go
+++ b/pkg/provider/helm/helm_test.go
@@ -13,8 +13,8 @@ import (
 
 func TestHelmSPIREProvider(t *testing.T) {
 	trustZoneProto := &trust_zone_proto.TrustZone{TrustDomain: "foo.bar"}
-	spireValues := map[string]interface{}{}
-	spireCRDsValues := map[string]interface{}{}
+	spireValues := map[string]any{}
+	spireCRDsValues := map[string]any{}
 
 	p, err := NewHelmSPIREProvider(context.Background(), trustZoneProto, spireValues, spireCRDsValues)
 	assert.Nil(t, err)

--- a/pkg/spire/spire.go
+++ b/pkg/spire/spire.go
@@ -442,7 +442,7 @@ func getServerCABundle(ctx context.Context, client *kubeutil.Client) (string, er
 }
 
 func parseServerCABundle(stdout []byte) (string, error) {
-	var data map[string]interface{}
+	var data map[string]any
 	if err := json.Unmarshal(stdout, &data); err != nil {
 		return "", err
 	}
@@ -450,7 +450,7 @@ func parseServerCABundle(stdout []byte) (string, error) {
 }
 
 type federatedBundles struct {
-	Bundles []map[string]interface{} `json:"bundles"`
+	Bundles []map[string]any `json:"bundles"`
 }
 
 func getFederatedBundles(ctx context.Context, client *kubeutil.Client) (map[string]string, error) {


### PR DESCRIPTION
### Summary
As part of changes introduced with #57, this PR is a follow up to replace instances of `map[string]interface{}` to use the `any` alias, as proposed [here](https://github.com/cofide/cofidectl/pull/62#discussion_r1870020000).