### PR TITLE
feat: Use `--profile` flag to set the SPIRE agent Envoy SDS configuration

### DIFF
--- a/cmd/cofidectl/cmd/trustzone/trustzone.go
+++ b/cmd/cofidectl/cmd/trustzone/trustzone.go
@@ -111,6 +111,7 @@ type addOpts struct {
 	trustDomain       string
 	kubernetesCluster string
 	context           string
+	trustProvider     string
 	profile           string
 	jwtIssuer         string
 }
@@ -145,7 +146,8 @@ func (c *TrustZoneCommand) GetAddCommand() *cobra.Command {
 				TrustDomain:       opts.trustDomain,
 				KubernetesCluster: &opts.kubernetesCluster,
 				KubernetesContext: &opts.context,
-				TrustProvider:     &trust_provider_proto.TrustProvider{Kind: &opts.profile},
+				TrustProvider:     &trust_provider_proto.TrustProvider{Kind: &opts.trustProvider},
+				Profile:           &opts.profile,
 				JwtIssuer:         &opts.jwtIssuer,
 			}
 
@@ -162,7 +164,8 @@ func (c *TrustZoneCommand) GetAddCommand() *cobra.Command {
 	f.StringVar(&opts.trustDomain, "trust-domain", "", "Trust domain to use for this trust zone")
 	f.StringVar(&opts.kubernetesCluster, "kubernetes-cluster", "", "Kubernetes cluster associated with this trust zone")
 	f.StringVar(&opts.context, "kubernetes-context", "", "Kubernetes context to use for this trust zone")
-	f.StringVar(&opts.profile, "profile", "kubernetes", "Cofide profile used in the installation (e.g. kubernetes, istio). Defaults to kubernetes")
+	f.StringVar(&opts.trustProvider, "trust-provider", "kubernetes", "Cofide trust provider used in the installation (e.g. kubernetes, unix)")
+	f.StringVar(&opts.profile, "profile", "kubernetes", "Cofide profile used in the installation (e.g. kubernetes, istio)")
 	f.StringVar(&opts.jwtIssuer, "jwt-issuer", "", "JWT issuer to use for this trust zone")
 
 	cobra.CheckErr(cmd.MarkFlagRequired("trust-domain"))

--- a/cmd/cofidectl/cmd/trustzone/trustzone.go
+++ b/cmd/cofidectl/cmd/trustzone/trustzone.go
@@ -11,16 +11,16 @@ import (
 	"slices"
 	"strconv"
 
-	cmdcontext "github.com/cofide/cofidectl/pkg/cmd/context"
 	"github.com/cofide/cofidectl/cmd/cofidectl/cmd/trustzone/helm"
+	cmdcontext "github.com/cofide/cofidectl/pkg/cmd/context"
 	"github.com/manifoldco/promptui"
 
 	trust_provider_proto "github.com/cofide/cofide-api-sdk/gen/go/proto/trust_provider/v1alpha1"
 	trust_zone_proto "github.com/cofide/cofide-api-sdk/gen/go/proto/trust_zone/v1alpha1"
-	"github.com/cofide/cofidectl/pkg/spire"
 	kubeutil "github.com/cofide/cofidectl/pkg/kube"
 	cofidectl_plugin "github.com/cofide/cofidectl/pkg/plugin"
 	helmprovider "github.com/cofide/cofidectl/pkg/provider/helm"
+	"github.com/cofide/cofidectl/pkg/spire"
 	"github.com/olekukonko/tablewriter"
 	"github.com/spf13/cobra"
 	"github.com/spiffe/go-spiffe/v2/spiffeid"
@@ -162,7 +162,7 @@ func (c *TrustZoneCommand) GetAddCommand() *cobra.Command {
 	f.StringVar(&opts.trustDomain, "trust-domain", "", "Trust domain to use for this trust zone")
 	f.StringVar(&opts.kubernetesCluster, "kubernetes-cluster", "", "Kubernetes cluster associated with this trust zone")
 	f.StringVar(&opts.context, "kubernetes-context", "", "Kubernetes context to use for this trust zone")
-	f.StringVar(&opts.profile, "profile", "kubernetes", "Cofide profile used in the installation (e.g. kubernetes, istio)")
+	f.StringVar(&opts.profile, "profile", "kubernetes", "Cofide profile used in the installation (e.g. kubernetes, istio). Defaults to kubernetes")
 	f.StringVar(&opts.jwtIssuer, "jwt-issuer", "", "JWT issuer to use for this trust zone")
 
 	cobra.CheckErr(cmd.MarkFlagRequired("trust-domain"))

--- a/internal/pkg/config/schema.cue
+++ b/internal/pkg/config/schema.cue
@@ -6,6 +6,7 @@
 	kubernetes_cluster!: string
 	kubernetes_context!: string
 	trust_provider!: #TrustProvider
+	profile!: string
 	bundle_endpoint_url?: string
 	bundle?: string
 	federations: [...#Federation]

--- a/internal/pkg/config/testdata/config/full.yaml
+++ b/internal/pkg/config/testdata/config/full.yaml
@@ -23,6 +23,7 @@ trust_zones:
                     create: true
         spire-server:
             logLevel: INFO
+      profile: kubernetes
     - name: tz2
       trust_domain: td2
       kubernetes_cluster: local2
@@ -39,6 +40,7 @@ trust_zones:
           federates_with:
             - tz1
       jwt_issuer: https://tz2.example.com
+      profile: kubernetes
 attestation_policies:
     - name: ap1
       kubernetes:

--- a/internal/pkg/test/fixtures/fixtures.go
+++ b/internal/pkg/test/fixtures/fixtures.go
@@ -25,6 +25,7 @@ var trustZoneFixtures map[string]*trust_zone_proto.TrustZone = map[string]*trust
 		TrustProvider: &trust_provider_proto.TrustProvider{
 			Kind: StringPtr("kubernetes"),
 		},
+		Profile:           StringPtr("kubernetes"),
 		BundleEndpointUrl: StringPtr("127.0.0.1"),
 		Federations: []*federation_proto.Federation{
 			{
@@ -68,6 +69,7 @@ var trustZoneFixtures map[string]*trust_zone_proto.TrustZone = map[string]*trust
 		TrustProvider: &trust_provider_proto.TrustProvider{
 			Kind: StringPtr("kubernetes"),
 		},
+		Profile:           StringPtr("kubernetes"),
 		BundleEndpointUrl: StringPtr("127.0.0.2"),
 		Federations: []*federation_proto.Federation{
 			{
@@ -93,6 +95,7 @@ var trustZoneFixtures map[string]*trust_zone_proto.TrustZone = map[string]*trust
 		TrustProvider: &trust_provider_proto.TrustProvider{
 			Kind: StringPtr("kubernetes"),
 		},
+		Profile:             StringPtr("kubernetes"),
 		BundleEndpointUrl:   StringPtr("127.0.0.3"),
 		Federations:         []*federation_proto.Federation{},
 		AttestationPolicies: []*ap_binding_proto.APBinding{},

--- a/internal/pkg/test/fixtures/fixtures.go
+++ b/internal/pkg/test/fixtures/fixtures.go
@@ -100,6 +100,20 @@ var trustZoneFixtures map[string]*trust_zone_proto.TrustZone = map[string]*trust
 		Federations:         []*federation_proto.Federation{},
 		AttestationPolicies: []*ap_binding_proto.APBinding{},
 	},
+	// tz3 has no federations or bound attestation policies and uses the istio profile.
+	"tz4": {
+		Name:              "tz4",
+		TrustDomain:       "td4",
+		KubernetesCluster: StringPtr("local4"),
+		KubernetesContext: StringPtr("kind-local4"),
+		TrustProvider: &trust_provider_proto.TrustProvider{
+			Kind: StringPtr("kubernetes"),
+		},
+		Profile:             StringPtr("istio"),
+		BundleEndpointUrl:   StringPtr("127.0.0.4"),
+		Federations:         []*federation_proto.Federation{},
+		AttestationPolicies: []*ap_binding_proto.APBinding{},
+	},
 }
 
 var attestationPolicyFixtures map[string]*attestation_policy_proto.AttestationPolicy = map[string]*attestation_policy_proto.AttestationPolicy{

--- a/internal/pkg/trustprovider/trustprovider.go
+++ b/internal/pkg/trustprovider/trustprovider.go
@@ -40,7 +40,7 @@ type TrustProvider struct {
 	Kind         string
 	AgentConfig  TrustProviderAgentConfig
 	ServerConfig TrustProviderServerConfig
-	SDSConfig    SDSConfig
+	SDSConfig    map[string]any
 	Proto        *trust_provider_proto.TrustProvider
 }
 
@@ -83,11 +83,11 @@ func (tp *TrustProvider) GetValues() error {
 		}
 		// Uses the Istio recommended values by default.
 		// https://istio.io/latest/docs/ops/integrations/spire/#spiffe-federation
-		tp.SDSConfig = SDSConfig{
-			Enabled:               true,
-			DefaultSVIDName:       "default",
-			DefaultBundleName:     "null",
-			DefaultAllBundlesName: "ROOTCA",
+		tp.SDSConfig = map[string]any{
+			"enabled":               true,
+			"defaultSVIDName":       "default",
+			"defaultBundleName":     "null",
+			"defaultAllBundlesName": "ROOTCA",
 		}
 	default:
 		return fmt.Errorf("an unknown trust provider profile was specified: %s", tp.Kind)

--- a/internal/pkg/trustprovider/trustprovider.go
+++ b/internal/pkg/trustprovider/trustprovider.go
@@ -14,11 +14,33 @@ const (
 	kubernetesPsat          string = "k8sPsat"
 )
 
+type TrustProviderAgentConfig struct {
+	WorkloadAttestor        string         `yaml:"workloadAttestor"`
+	WorkloadAttestorEnabled bool           `yaml:"workloadAttestorEnabled"`
+	WorkloadAttestorConfig  map[string]any `yaml:"workloadAttestorConfig"`
+	NodeAttestor            string         `yaml:"nodeAttestor"`
+	NodeAttestorEnabled     bool           `yaml:"nodeAttestorEnabled"`
+}
+
+type TrustProviderServerConfig struct {
+	NodeAttestor        string         `yaml:"nodeAttestor"`
+	NodeAttestorEnabled bool           `yaml:"nodeAttestorEnabled"`
+	NodeAttestorConfig  map[string]any `yaml:"nodeAttestorConfig"`
+}
+
+type SDSConfig struct {
+	Enabled               bool   `yaml:"enabled"`
+	DefaultSVIDName       string `yaml:"defaultSVIDName"`
+	DefaultBundleName     string `yaml:"defaultBundleName"`
+	DefaultAllBundlesName string `yaml:"defaultAllBundlesName"`
+}
+
 type TrustProvider struct {
 	Name         string
 	Kind         string
 	AgentConfig  TrustProviderAgentConfig
 	ServerConfig TrustProviderServerConfig
+	SDSConfig    SDSConfig
 	Proto        *trust_provider_proto.TrustProvider
 }
 
@@ -59,22 +81,16 @@ func (tp *TrustProvider) GetValues() error {
 				"allowedPodLabelKeys":     []string{},
 			},
 		}
+		// Uses the Istio recommended values by default.
+		// https://istio.io/latest/docs/ops/integrations/spire/#spiffe-federation
+		tp.SDSConfig = SDSConfig{
+			Enabled:               true,
+			DefaultSVIDName:       "default",
+			DefaultBundleName:     "null",
+			DefaultAllBundlesName: "ROOTCA",
+		}
 	default:
 		return fmt.Errorf("an unknown trust provider profile was specified: %s", tp.Kind)
 	}
 	return nil
-}
-
-type TrustProviderAgentConfig struct {
-	WorkloadAttestor        string         `yaml:"workloadAttestor"`
-	WorkloadAttestorEnabled bool           `yaml:"workloadAttestorEnabled"`
-	WorkloadAttestorConfig  map[string]any `yaml:"workloadAttestorConfig"`
-	NodeAttestor            string         `yaml:"nodeAttestor"`
-	NodeAttestorEnabled     bool           `yaml:"nodeAttestorEnabled"`
-}
-
-type TrustProviderServerConfig struct {
-	NodeAttestor        string         `yaml:"nodeAttestor"`
-	NodeAttestorEnabled bool           `yaml:"nodeAttestorEnabled"`
-	NodeAttestorConfig  map[string]any `yaml:"nodeAttestorConfig"`
 }

--- a/internal/pkg/trustprovider/trustprovider.go
+++ b/internal/pkg/trustprovider/trustprovider.go
@@ -28,19 +28,11 @@ type TrustProviderServerConfig struct {
 	NodeAttestorConfig  map[string]any `yaml:"nodeAttestorConfig"`
 }
 
-type SDSConfig struct {
-	Enabled               bool   `yaml:"enabled"`
-	DefaultSVIDName       string `yaml:"defaultSVIDName"`
-	DefaultBundleName     string `yaml:"defaultBundleName"`
-	DefaultAllBundlesName string `yaml:"defaultAllBundlesName"`
-}
-
 type TrustProvider struct {
 	Name         string
 	Kind         string
 	AgentConfig  TrustProviderAgentConfig
 	ServerConfig TrustProviderServerConfig
-	SDSConfig    map[string]any
 	Proto        *trust_provider_proto.TrustProvider
 }
 
@@ -81,16 +73,8 @@ func (tp *TrustProvider) GetValues() error {
 				"allowedPodLabelKeys":     []string{},
 			},
 		}
-		// Uses the Istio recommended values by default.
-		// https://istio.io/latest/docs/ops/integrations/spire/#spiffe-federation
-		tp.SDSConfig = map[string]any{
-			"enabled":               true,
-			"defaultSVIDName":       "default",
-			"defaultBundleName":     "null",
-			"defaultAllBundlesName": "ROOTCA",
-		}
 	default:
-		return fmt.Errorf("an unknown trust provider profile was specified: %s", tp.Kind)
+		return fmt.Errorf("an unknown trust provider kind was specified: %s", tp.Kind)
 	}
 	return nil
 }

--- a/pkg/provider/helm/values_test.go
+++ b/pkg/provider/helm/values_test.go
@@ -67,6 +67,12 @@ func TestHelmValuesGenerator_GenerateValues_success(t *testing.T) {
 							"enabled": true,
 						},
 					},
+					"sds": map[string]any{
+						"enabled":               true,
+						"defaultSVIDName":       "default",
+						"defaultBundleName":     "null",
+						"defaultAllBundlesName": "ROOTCA",
+					},
 					"server": Values{
 						"address": "spire-server.spire",
 					},
@@ -150,6 +156,12 @@ func TestHelmValuesGenerator_GenerateValues_success(t *testing.T) {
 						"k8sPsat": Values{
 							"enabled": true,
 						},
+					},
+					"sds": map[string]any{
+						"enabled":               true,
+						"defaultSVIDName":       "default",
+						"defaultBundleName":     "null",
+						"defaultAllBundlesName": "ROOTCA",
 					},
 					"server": Values{
 						"address": "spire-server.spire",
@@ -306,6 +318,12 @@ func TestHelmValuesGenerator_GenerateValues_AdditionalValues(t *testing.T) {
 						"k8sPsat": Values{
 							"enabled": true,
 						},
+					},
+					"sds": map[string]any{
+						"enabled":               true,
+						"defaultSVIDName":       "default",
+						"defaultBundleName":     "null",
+						"defaultAllBundlesName": "ROOTCA",
 					},
 					"server": Values{
 						"address": "spire-server.spire",
@@ -941,6 +959,12 @@ func TestSpireAgentValues_GenerateValues(t *testing.T) {
 					NodeAttestor:        "k8sPsat",
 					NodeAttestorEnabled: true,
 				},
+				sdsConfig: map[string]any{
+					"enabled":               true,
+					"defaultSVIDName":       "default",
+					"defaultBundleName":     "null",
+					"defaultAllBundlesName": "ROOTCA",
+				},
 				spireServerAddress: "spire-server.spire",
 			},
 			want: map[string]any{
@@ -951,6 +975,12 @@ func TestSpireAgentValues_GenerateValues(t *testing.T) {
 						"k8sPsat": map[string]any{
 							"enabled": true,
 						},
+					},
+					"sds": map[string]any{
+						"enabled":               true,
+						"defaultSVIDName":       "default",
+						"defaultBundleName":     "null",
+						"defaultAllBundlesName": "ROOTCA",
 					},
 					"server": map[string]any{
 						"address": "spire-server.spire",
@@ -985,6 +1015,12 @@ func TestSpireAgentValues_GenerateValues(t *testing.T) {
 					NodeAttestor:        "k8sPsat",
 					NodeAttestorEnabled: true,
 				},
+				sdsConfig: map[string]any{
+					"enabled":               true,
+					"defaultSVIDName":       "default",
+					"defaultBundleName":     "null",
+					"defaultAllBundlesName": "ROOTCA",
+				},
 				spireServerAddress: "spire-server.spire",
 			},
 			want:      nil,
@@ -1002,6 +1038,12 @@ func TestSpireAgentValues_GenerateValues(t *testing.T) {
 					WorkloadAttestorConfig:  map[string]any{},
 					NodeAttestor:            "k8sPsat",
 					NodeAttestorEnabled:     true,
+				},
+				sdsConfig: map[string]any{
+					"enabled":               true,
+					"defaultSVIDName":       "default",
+					"defaultBundleName":     "null",
+					"defaultAllBundlesName": "ROOTCA",
 				},
 				spireServerAddress: "spire-server.spire",
 			},
@@ -1026,6 +1068,12 @@ func TestSpireAgentValues_GenerateValues(t *testing.T) {
 					},
 					NodeAttestor:        "k8sPsat",
 					NodeAttestorEnabled: true,
+				},
+				sdsConfig: map[string]any{
+					"enabled":               true,
+					"defaultSVIDName":       "default",
+					"defaultBundleName":     "null",
+					"defaultAllBundlesName": "ROOTCA",
 				},
 				spireServerAddress: "spire-server.spire",
 			},

--- a/pkg/provider/helm/values_test.go
+++ b/pkg/provider/helm/values_test.go
@@ -70,8 +70,8 @@ func TestHelmValuesGenerator_GenerateValues_success(t *testing.T) {
 					"sds": map[string]any{
 						"enabled":               true,
 						"defaultSVIDName":       "default",
-						"defaultBundleName":     "null",
-						"defaultAllBundlesName": "ROOTCA",
+						"defaultBundleName":     "ROOTCA",
+						"defaultAllBundlesName": "ALL",
 					},
 					"server": Values{
 						"address": "spire-server.spire",
@@ -160,8 +160,8 @@ func TestHelmValuesGenerator_GenerateValues_success(t *testing.T) {
 					"sds": map[string]any{
 						"enabled":               true,
 						"defaultSVIDName":       "default",
-						"defaultBundleName":     "null",
-						"defaultAllBundlesName": "ROOTCA",
+						"defaultBundleName":     "ROOTCA",
+						"defaultAllBundlesName": "ALL",
 					},
 					"server": Values{
 						"address": "spire-server.spire",
@@ -322,8 +322,8 @@ func TestHelmValuesGenerator_GenerateValues_AdditionalValues(t *testing.T) {
 					"sds": map[string]any{
 						"enabled":               true,
 						"defaultSVIDName":       "default",
-						"defaultBundleName":     "null",
-						"defaultAllBundlesName": "ROOTCA",
+						"defaultBundleName":     "ROOTCA",
+						"defaultAllBundlesName": "ALL",
 					},
 					"server": Values{
 						"address": "spire-server.spire",
@@ -421,7 +421,7 @@ func TestHelmValuesGenerator_GenerateValues_failure(t *testing.T) {
 				tz.TrustProvider.Kind = fixtures.StringPtr("invalid-tp")
 				return tz
 			}(),
-			wantErrString: "an unknown trust provider profile was specified: invalid-tp",
+			wantErrString: "an unknown trust provider kind was specified: invalid-tp",
 		},
 		{
 			name: "unknown attestation policy",
@@ -962,8 +962,8 @@ func TestSpireAgentValues_GenerateValues(t *testing.T) {
 				sdsConfig: map[string]any{
 					"enabled":               true,
 					"defaultSVIDName":       "default",
-					"defaultBundleName":     "null",
-					"defaultAllBundlesName": "ROOTCA",
+					"defaultBundleName":     "ROOTCA",
+					"defaultAllBundlesName": "ALL",
 				},
 				spireServerAddress: "spire-server.spire",
 			},
@@ -979,8 +979,8 @@ func TestSpireAgentValues_GenerateValues(t *testing.T) {
 					"sds": map[string]any{
 						"enabled":               true,
 						"defaultSVIDName":       "default",
-						"defaultBundleName":     "null",
-						"defaultAllBundlesName": "ROOTCA",
+						"defaultBundleName":     "ROOTCA",
+						"defaultAllBundlesName": "ALL",
 					},
 					"server": map[string]any{
 						"address": "spire-server.spire",
@@ -1018,8 +1018,8 @@ func TestSpireAgentValues_GenerateValues(t *testing.T) {
 				sdsConfig: map[string]any{
 					"enabled":               true,
 					"defaultSVIDName":       "default",
-					"defaultBundleName":     "null",
-					"defaultAllBundlesName": "ROOTCA",
+					"defaultBundleName":     "ROOTCA",
+					"defaultAllBundlesName": "ALL",
 				},
 				spireServerAddress: "spire-server.spire",
 			},
@@ -1042,8 +1042,8 @@ func TestSpireAgentValues_GenerateValues(t *testing.T) {
 				sdsConfig: map[string]any{
 					"enabled":               true,
 					"defaultSVIDName":       "default",
-					"defaultBundleName":     "null",
-					"defaultAllBundlesName": "ROOTCA",
+					"defaultBundleName":     "ROOTCA",
+					"defaultAllBundlesName": "ALL",
 				},
 				spireServerAddress: "spire-server.spire",
 			},
@@ -1072,8 +1072,8 @@ func TestSpireAgentValues_GenerateValues(t *testing.T) {
 				sdsConfig: map[string]any{
 					"enabled":               true,
 					"defaultSVIDName":       "default",
-					"defaultBundleName":     "null",
-					"defaultAllBundlesName": "ROOTCA",
+					"defaultBundleName":     "ROOTCA",
+					"defaultAllBundlesName": "ALL",
 				},
 				spireServerAddress: "spire-server.spire",
 			},


### PR DESCRIPTION
### Summary
- This PR adds logic to dynamically set the SPIRE agent's Envoy SDS configuration based on the `-profile` flag present on the `cofidectl trust-zone add` command.
- Two `profile` types are currently supported, namely `kubernetes` and `istio`, with the default being `kubernetes`.