### PR TITLE
Adding --quiet mode

### DIFF
--- a/cmd/cofidectl/cmd/down.go
+++ b/cmd/cofidectl/cmd/down.go
@@ -39,7 +39,7 @@ func (d *DownCommand) DownCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			return statusspinner.WatchProvisionStatus(cmd.Context(), statusCh)
+			return statusspinner.WatchProvisionStatus(cmd.Context(), statusCh, false)
 		},
 	}
 	return cmd

--- a/cmd/cofidectl/cmd/statusspinner/statusspinner.go
+++ b/cmd/cofidectl/cmd/statusspinner/statusspinner.go
@@ -47,7 +47,7 @@ func (ss *statusSpinner) update(status *provisionpb.Status) {
 
 // WatchProvisionStatus reads Status objects from a channel and manages status spinners to consume the events.
 // The channel may receive status objects for multiple sequential operations, each of which should use its own spinner.
-func WatchProvisionStatus(ctx context.Context, statusCh <-chan *provisionpb.Status) error {
+func WatchProvisionStatus(ctx context.Context, statusCh <-chan *provisionpb.Status, quiet bool) error {
 	var spinner *statusSpinner
 	for {
 		select {
@@ -57,10 +57,14 @@ func WatchProvisionStatus(ctx context.Context, statusCh <-chan *provisionpb.Stat
 			if !ok {
 				return nil
 			}
+
 			if spinner == nil {
 				spinner = new()
-				spinner.start()
+				if !quiet {
+					spinner.start()
+				}
 			}
+
 			spinner.update(status)
 			if status.GetError() != "" {
 				return errors.New(status.GetError())

--- a/cmd/cofidectl/cmd/up.go
+++ b/cmd/cofidectl/cmd/up.go
@@ -23,7 +23,12 @@ var upCmdDesc = `
 This command installs a Cofide configuration
 `
 
+type UpOpts struct {
+	quiet bool
+}
+
 func (u *UpCommand) UpCmd() *cobra.Command {
+	opts := UpOpts{}
 	cmd := &cobra.Command{
 		Use:   "up [ARGS]",
 		Short: "Installs a Cofide configuration",
@@ -40,8 +45,17 @@ func (u *UpCommand) UpCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			return statusspinner.WatchProvisionStatus(cmd.Context(), statusCh)
+
+			return statusspinner.WatchProvisionStatus(
+				cmd.Context(),
+				statusCh,
+				opts.quiet,
+			)
 		},
 	}
+
+	f := cmd.Flags()
+	f.BoolVar(&opts.quiet, "quiet", false, "Minimise logging from installation")
+
 	return cmd
 }

--- a/tests/integration/single-trust-zone/test.sh
+++ b/tests/integration/single-trust-zone/test.sh
@@ -25,7 +25,7 @@ function configure() {
 }
 
 function up() {
-  ./cofidectl up
+  ./cofidectl up --quiet
 }
 
 function list_resources() {


### PR DESCRIPTION
(implements https://github.com/cofide/cofidectl/issues/67)

* Adds `--quiet` opt to `up` command, which switches off the cursor animation
* Adds `quiet bool` to `WatchProvisionStatus` to conditional the `spinner.Start()` invocation per event. The quiet true case simply doesn't start the spinner
* Concretely sets `down` to false (these logs are less verbose, and we don't encounter `cofidectl down` as much in CI)
* `single-trust-zone` test now uses `./cofidectl up --quiet` (perhaps a better place for this, a new test?)