### PR TITLE
Disable the default clusterSPIFFEID

### DIFF
--- a/pkg/provider/helm/values_test.go
+++ b/pkg/provider/helm/values_test.go
@@ -94,7 +94,7 @@ func TestHelmValuesGenerator_GenerateValues_success(t *testing.T) {
 						"identities": Values{
 							"clusterSPIFFEIDs": Values{
 								"default": Values{
-									"enabled": true,
+									"enabled": false,
 								},
 							},
 						},
@@ -293,7 +293,7 @@ func TestHelmValuesGenerator_GenerateValues_success(t *testing.T) {
 						"identities": Values{
 							"clusterSPIFFEIDs": Values{
 								"default": Values{
-									"enabled": true,
+									"enabled": false,
 								},
 							},
 						},
@@ -430,7 +430,7 @@ func TestHelmValuesGenerator_GenerateValues_AdditionalValues(t *testing.T) {
 						"identities": Values{
 							"clusterSPIFFEIDs": Values{
 								"default": Values{
-									"enabled": true,
+									"enabled": false,
 								},
 							},
 							"clusterFederatedTrustDomains": Values{


### PR DESCRIPTION
If you create a trust zone with no attestation policies bound to it, we
previously enabled the default clusterSPIFFEID. This resource matches
any pod in a non-spire namespace.

This behaviour is surprising, and we should instead rely on an explicit
catch-all attestation policy being bound to the trust zone:

  cofidectl attestation-policy add kubernetes --name catch-all

This commit fixes the issue by disabling the default clusterSPIFFEID.

Fixes: #92
