### PR TITLE
feat: Update reference to the `cofidectl-debug-container` image name

### DIFF
--- a/internal/pkg/workload/workload.go
+++ b/internal/pkg/workload/workload.go
@@ -20,7 +20,7 @@ import (
 )
 
 const debugContainerNamePrefix = "cofidectl-debug"
-const debugContainerImage = "ghcr.io/cofide/cofidectl-debug-container/cmd:v0.1.0"
+const debugContainerImage = "ghcr.io/cofide/cofidectl-debug-container:v0.1.0"
 
 type Workload struct {
 	Name             string


### PR DESCRIPTION
### Summary
- This PR updates the `cofidectl-debug-container/cmd` image reference to use the updated `cofidectl-debug-container` name, as required by #107.