### PR TITLE
feat: `cofidectl workload status` command added to each integration test

### DIFF
--- a/tests/integration/federation/test.sh
+++ b/tests/integration/federation/test.sh
@@ -117,9 +117,17 @@ function show_workload_status() {
     -n $NAMESPACE_POLICY_NAMESPACE \
     -o jsonpath='{.items[0].metadata.name}' \
     --context $K8S_CLUSTER_1_CONTEXT)
-  ./cofidectl workload status --namespace $NAMESPACE_POLICY_NAMESPACE \
+  WORKLOAD_STATUS_RESPONSE=$(./cofidectl workload status --namespace $NAMESPACE_POLICY_NAMESPACE \
     --pod-name $POD_NAME \
-    --trust-zone $TRUST_ZONE_1
+    --trust-zone $TRUST_ZONE_1)
+
+  if [[ ! $WORKLOAD_STATUS_RESPONSE == *"SVID verified against trust bundle"* ]]; then
+    echo "cofidectl workload status unsuccessful"
+    exit 1
+  fi
+
+  echo "cofidectl workload status successful"
+  exit 0
 }
 
 function down() {

--- a/tests/integration/federation/test.sh
+++ b/tests/integration/federation/test.sh
@@ -80,6 +80,14 @@ function show_status() {
   ./cofidectl workload list
   ./cofidectl trust-zone status $TRUST_ZONE_1
   ./cofidectl trust-zone status $TRUST_ZONE_2
+
+  POD_NAME=$(kubectl get pods -l app=ping-pong-client \
+    -n $NAMESPACE_POLICY_NAMESPACE \
+    -o jsonpath='{.items[0].metadata.name}' \
+    --context $K8S_CLUSTER_1_CONTEXT)
+  ./cofidectl workload status --namespace $NAMESPACE_POLICY_NAMESPACE \
+    --pod-name $POD_NAME \
+    --trust-zone $TRUST_ZONE_1
 }
 
 function run_tests() {

--- a/tests/integration/federation/test.sh
+++ b/tests/integration/federation/test.sh
@@ -121,7 +121,7 @@ function show_workload_status() {
     --pod-name $POD_NAME \
     --trust-zone $TRUST_ZONE_1)
 
-  if [[ ! $WORKLOAD_STATUS_RESPONSE == *"SVID verified against trust bundle"* ]]; then
+  if [[ $WORKLOAD_STATUS_RESPONSE != *"SVID verified against trust bundle"* ]]; then
     echo "cofidectl workload status unsuccessful"
     exit 1
   fi

--- a/tests/integration/federation/test.sh
+++ b/tests/integration/federation/test.sh
@@ -80,14 +80,6 @@ function show_status() {
   ./cofidectl workload list
   ./cofidectl trust-zone status $TRUST_ZONE_1
   ./cofidectl trust-zone status $TRUST_ZONE_2
-
-  POD_NAME=$(kubectl get pods -l app=ping-pong-client \
-    -n $NAMESPACE_POLICY_NAMESPACE \
-    -o jsonpath='{.items[0].metadata.name}' \
-    --context $K8S_CLUSTER_1_CONTEXT)
-  ./cofidectl workload status --namespace $NAMESPACE_POLICY_NAMESPACE \
-    --pod-name $POD_NAME \
-    --trust-zone $TRUST_ZONE_1
 }
 
 function run_tests() {
@@ -120,6 +112,16 @@ function post_deploy() {
   fi
 }
 
+function show_workload_status() {
+  POD_NAME=$(kubectl get pods -l app=ping-pong-client \
+    -n $NAMESPACE_POLICY_NAMESPACE \
+    -o jsonpath='{.items[0].metadata.name}' \
+    --context $K8S_CLUSTER_1_CONTEXT)
+  ./cofidectl workload status --namespace $NAMESPACE_POLICY_NAMESPACE \
+    --pod-name $POD_NAME \
+    --trust-zone $TRUST_ZONE_1
+}
+
 function down() {
   ./cofidectl down
 }
@@ -134,6 +136,7 @@ function main() {
   show_status
   run_tests
   post_deploy
+  show_workload_status
   down
   echo "Success!"
 }

--- a/tests/integration/single-trust-zone/test.sh
+++ b/tests/integration/single-trust-zone/test.sh
@@ -89,22 +89,7 @@ function show_workload_status() {
     --pod-name $POD_NAME \
     --trust-zone $TRUST_ZONE)
 
-  ERROR_PATTERNS=(
-    "Unable to create workload API client"
-    "unable to fetch X.509 trust bundles"
-    "unable to fetch X.509 SVIDs"
-    "SVID verification failed"
-    "No trust bundle found for trust domain"
-  )
-
-  for pattern in "${ERROR_PATTERNS[@]}"; do
-    if [[ $WORKLOAD_STATUS_RESPONSE == *"$pattern"* ]]; then
-      echo "cofidectl workload status unsuccessful"
-      exit 1
-    fi
-  done
-
-  if [[ ! $WORKLOAD_STATUS_RESPONSE == *"Trust bundles received"* ]] && [[ ! $WORKLOAD_STATUS_RESPONSE == *"SVIDs received"* ]]; then
+  if [[ ! $WORKLOAD_STATUS_RESPONSE == *"SVID verified against trust bundle"* ]]; then
     echo "cofidectl workload status unsuccessful"
     exit 1
   fi

--- a/tests/integration/single-trust-zone/test.sh
+++ b/tests/integration/single-trust-zone/test.sh
@@ -89,7 +89,7 @@ function show_workload_status() {
     --pod-name $POD_NAME \
     --trust-zone $TRUST_ZONE)
 
-  if [[ ! $WORKLOAD_STATUS_RESPONSE == *"SVID verified against trust bundle"* ]]; then
+  if [[ $WORKLOAD_STATUS_RESPONSE != *"SVID verified against trust bundle"* ]]; then
     echo "cofidectl workload status unsuccessful"
     exit 1
   fi

--- a/tests/integration/single-trust-zone/test.sh
+++ b/tests/integration/single-trust-zone/test.sh
@@ -55,6 +55,14 @@ function show_status() {
   ./cofidectl workload discover
   ./cofidectl workload list
   ./cofidectl trust-zone status $TRUST_ZONE
+
+  POD_NAME=$(kubectl get pods -l app=ping-pong-client \
+    -n $NAMESPACE_POLICY_NAMESPACE \
+    -o jsonpath='{.items[0].metadata.name}' \
+    --context $K8S_CLUSTER_CONTEXT)
+  ./cofidectl workload status --namespace $NAMESPACE_POLICY_NAMESPACE \
+    --pod-name $POD_NAME \
+    --trust-zone $TRUST_ZONE
 }
 
 function run_tests() {

--- a/tests/integration/single-trust-zone/test.sh
+++ b/tests/integration/single-trust-zone/test.sh
@@ -55,14 +55,6 @@ function show_status() {
   ./cofidectl workload discover
   ./cofidectl workload list
   ./cofidectl trust-zone status $TRUST_ZONE
-
-  POD_NAME=$(kubectl get pods -l app=ping-pong-client \
-    -n $NAMESPACE_POLICY_NAMESPACE \
-    -o jsonpath='{.items[0].metadata.name}' \
-    --context $K8S_CLUSTER_CONTEXT)
-  ./cofidectl workload status --namespace $NAMESPACE_POLICY_NAMESPACE \
-    --pod-name $POD_NAME \
-    --trust-zone $TRUST_ZONE
 }
 
 function run_tests() {
@@ -88,6 +80,16 @@ function wait_for_pong() {
   return 1
 }
 
+function show_workload_status() {
+  POD_NAME=$(kubectl get pods -l app=ping-pong-client \
+    -n $NAMESPACE_POLICY_NAMESPACE \
+    -o jsonpath='{.items[0].metadata.name}' \
+    --context $K8S_CLUSTER_CONTEXT)
+  ./cofidectl workload status --namespace $NAMESPACE_POLICY_NAMESPACE \
+    --pod-name $POD_NAME \
+    --trust-zone $TRUST_ZONE
+}
+
 function down() {
   ./cofidectl down
 }
@@ -100,6 +102,7 @@ function main() {
   show_config
   show_status
   run_tests
+  show_workload_status
   down
   echo "Success!"
 }


### PR DESCRIPTION
### Summary
- This small PR adds the `cofidectl workload status` command to each of the integration tests as required by #107.