### PR TITLE
fix: Update `goheader` linter setting to support 2024 and onwards

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@v6
         with:
-          args: --timeout=5m
+          args: --timeout=5m --config=.golangci.yaml
 
   build-test:
     name: build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@v6
         with:
-          args: --timeout=5m --config=.golangci.yaml
+          args: --timeout=5m
 
   build-test:
     name: build

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -8,8 +8,8 @@ linters-settings:
       const:
         COMPANY: Cofide Limited
       regexp:
-        YEAR: 202[4-9]|20[3-9][0-9]|2[1-9][0-9][0-9]
+        VALID_YEAR: 202[4-9]|20[3-9][0-9]|2[1-9][0-9][0-9]
     # Require Cofide copyright and SPDX license in all source files.
     template: |-
-      Copyright {{ YEAR }} {{ COMPANY }}.
+      Copyright {{ VALID_YEAR }} {{ COMPANY }}.
       SPDX-License-Identifier: Apache-2.0

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -10,6 +10,6 @@ linters-settings:
       regexp:
         YEAR: 202[4-9]|20[3-9][0-9]|2[1-9][0-9][0-9]
     # Require Cofide copyright and SPDX license in all source files.
-    template: |
+    template: |-
       Copyright {{ YEAR }} {{ COMPANY }}.
       SPDX-License-Identifier: Apache-2.0

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -7,7 +7,9 @@ linters-settings:
     values:
       const:
         COMPANY: Cofide Limited
+      regexp:
+        YEAR: 202[4-9]|20[3-9][0-9]|2[1-9][0-9][0-9]
     # Require Cofide copyright and SPDX license in all source files.
     template: |
-      Copyright {{ MOD-YEAR-RANGE }} {{ COMPANY }}.
+      Copyright {{ YEAR }} {{ COMPANY }}.
       SPDX-License-Identifier: Apache-2.0

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -9,5 +9,5 @@ linters-settings:
         COMPANY: Cofide Limited
     # Require Cofide copyright and SPDX license in all source files.
     template: |
-      Copyright {{ MOD-YEAR }} {{ COMPANY }}.
+      Copyright {{ MOD-YEAR-RANGE }} {{ COMPANY }}.
       SPDX-License-Identifier: Apache-2.0


### PR DESCRIPTION
### Summary
- This PR adds a small fix to the `goheader` linter setting in `.golangci.yaml` to allow all years from 2024 and onwards to be valid, resolving the following error:
```
run golangci-lint
  Running [/home/runner/golangci-lint-1.63.1-linux-amd64/golangci-lint run  --timeout=5m] in [/home/runner/work/cofidectl/cofidectl] ...
  Received 1463000 of 1463000 (100.0%), 1.4 MBs/sec
  Error: pkg/plugin/local/local.go:1:14: Expected:2025, Actual: 2024 Cofide Limited. (goheader)
  // Copyright 2024 Cofide Limited.
               ^
  Error: pkg/plugin/local/local_test.go:1:14: Expected:2025, Actual: 2024 Cofide Limited. (goheader)
  // Copyright 2024 Cofide Limited.
               ^
  Error: internal/pkg/federation/federation.go:1:14: Expected:2025, Actual: 2024 Cofide Limited. (goheader)
  // Copyright 2024 Cofide Limited.
               ^
  
  Error: issues found
  Ran golangci-lint in 1915ms
``` 
