### PR TITLE
Add --log-level argument to root command

### DIFF
--- a/cmd/cofidectl/cmd/root_test.go
+++ b/cmd/cofidectl/cmd/root_test.go
@@ -1,0 +1,46 @@
+// Copyright 2025 Cofide Limited.
+// SPDX-License-Identifier: Apache-2.0
+
+package cmd
+
+import (
+	"log/slog"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_slogLevelFromString(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		level   string
+		want    slog.Level
+		wantErr bool
+	}{
+		{name: "debug", level: "debug", want: slog.LevelDebug},
+		{name: "warn", level: "warn", want: slog.LevelWarn},
+		{name: "info", level: "info", want: slog.LevelInfo},
+		{name: "error", level: "error", want: slog.LevelError},
+		{name: "debug upper", level: "DEBUG", want: slog.LevelDebug},
+		{name: "warn upper", level: "WARN", want: slog.LevelWarn},
+		{name: "info upper", level: "INFO", want: slog.LevelInfo},
+		{name: "error upper", level: "ERROR", want: slog.LevelError},
+		{name: "invalid", level: "invalid level", wantErr: true},
+		{name: "warning", level: "warning", wantErr: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := slogLevelFromString(tt.level)
+
+			if tt.wantErr {
+				require.Error(t, err, err)
+				assert.ErrorContains(t, err, "unexpected log level")
+			} else {
+				assert.Equal(t, got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/plugin/manager/manager.go
+++ b/pkg/plugin/manager/manager.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log/slog"
 	"maps"
 	"os"
 	"os/exec"
@@ -38,6 +39,7 @@ type PluginManager struct {
 	source           datasource.DataSource
 	provision        provision.Provision
 	clients          map[string]*go_plugin.Client
+	logLevel         hclog.Level
 }
 
 // grpcPluginLoader is a function that loads a gRPC plugin. The function should load a single
@@ -196,7 +198,7 @@ func (pm *PluginManager) loadGRPCPlugin(ctx context.Context, pluginName string, 
 	logger := hclog.New(&hclog.LoggerOptions{
 		Name:   "plugin",
 		Output: os.Stdout,
-		Level:  hclog.Error,
+		Level:  pm.logLevel,
 	})
 
 	grpcPlugin, err := pm.grpcPluginLoader(ctx, logger, pluginName, pluginCfg)
@@ -347,6 +349,11 @@ func (pm *PluginManager) SetPluginConfig(pluginName string, pluginConfig *struct
 	}
 	cfg.PluginConfig[pluginName] = pluginConfig
 	return pm.configLoader.Write(cfg)
+}
+
+// SetLogLevel sets the log level for gRPC plugins.
+func (pm *PluginManager) SetLogLevel(level slog.Level) {
+	pm.logLevel = hclog.LevelFromString(level.String())
 }
 
 // GetDefaultPlugins returns a `Plugins` message containing the default plugins.


### PR DESCRIPTION
This allows setting the log level threshold. The default is ERROR.
Currently we do not do much logging in cofidectl, but this may change
now that we can set the level.

The main benefit for now is that gRPC plugin log level is also set based
on this argument, giving more insight into plugin issues.

Fixes: #82
