### PR TITLE
Enable Helm chart recommendations, use 3-namespace deployment

### DIFF
--- a/internal/pkg/config/testdata/config/full.yaml
+++ b/internal/pkg/config/testdata/config/full.yaml
@@ -18,8 +18,10 @@ trust_zones:
       extra_helm_values:
         global:
             spire:
-                namespaces:
-                    create: true
+                caSubject:
+                    commonName: cn.example.com
+                    country: UK
+                    organization: acme-org
         spire-server:
             logLevel: INFO
       bundle_endpoint_profile: BUNDLE_ENDPOINT_PROFILE_HTTPS_SPIFFE

--- a/internal/pkg/config/testdata/config/full.yaml
+++ b/internal/pkg/config/testdata/config/full.yaml
@@ -20,10 +20,10 @@ trust_zones:
             spire:
                 caSubject:
                     commonName: cn.example.com
-                    country: UK
                     organization: acme-org
         spire-server:
             logLevel: INFO
+            nameOverride: custom-server-name
       bundle_endpoint_profile: BUNDLE_ENDPOINT_PROFILE_HTTPS_SPIFFE
       profile: kubernetes
       external_server: false

--- a/internal/pkg/test/fixtures/fixtures.go
+++ b/internal/pkg/test/fixtures/fixtures.go
@@ -46,15 +46,18 @@ var trustZoneFixtures map[string]*trust_zone_proto.TrustZone = map[string]*trust
 			ev := map[string]any{
 				"global": map[string]any{
 					"spire": map[string]any{
+						// Modify multiple values in the same map.
 						"caSubject": map[string]any{
-							"country":      "UK",
 							"organization": "acme-org",
 							"commonName":   "cn.example.com",
 						},
 					},
 				},
 				"spire-server": map[string]any{
+					// Modify an existing value.
 					"logLevel": "INFO",
+					// Customise a new value.
+					"nameOverride": "custom-server-name",
 				},
 			}
 			value, err := structpb.NewStruct(ev)

--- a/internal/pkg/test/fixtures/fixtures.go
+++ b/internal/pkg/test/fixtures/fixtures.go
@@ -46,8 +46,10 @@ var trustZoneFixtures map[string]*trust_zone_proto.TrustZone = map[string]*trust
 			ev := map[string]any{
 				"global": map[string]any{
 					"spire": map[string]any{
-						"namespaces": map[string]any{
-							"create": true,
+						"caSubject": map[string]any{
+							"country":      "UK",
+							"organization": "acme-org",
+							"commonName":   "cn.example.com",
 						},
 					},
 				},

--- a/internal/pkg/trustprovider/trustprovider.go
+++ b/internal/pkg/trustprovider/trustprovider.go
@@ -52,8 +52,9 @@ func (tp *TrustProvider) GetValues() error {
 			NodeAttestor:        kubernetesPsat,
 			NodeAttestorEnabled: true,
 			NodeAttestorConfig: map[string]any{
-				"enabled":                 true,
-				"serviceAccountAllowList": []string{"spire:spire-agent"},
+				"enabled": true,
+				// Rely on defaults?
+				"serviceAccountAllowList": []string{"spire-system:spire-agent"},
 				"audience":                []string{"spire-server"},
 				"allowedNodeLabelKeys":    []string{},
 				"allowedPodLabelKeys":     []string{},

--- a/internal/pkg/trustprovider/trustprovider.go
+++ b/internal/pkg/trustprovider/trustprovider.go
@@ -36,28 +36,18 @@ func (tp *TrustProvider) GetValues() error {
 	switch tp.Kind {
 	case "kubernetes":
 		tp.AgentConfig = TrustProviderAgentConfig{
-			WorkloadAttestor:        KubernetesTrustProvider,
-			WorkloadAttestorEnabled: true,
+			WorkloadAttestor: KubernetesTrustProvider,
 			WorkloadAttestorConfig: map[string]any{
-				"enabled":                     true,
-				"skipKubeletVerification":     true,
-				"disableContainerSelectors":   true,
-				"useNewContainerLocator":      false,
-				"verboseContainerLocatorLogs": false,
+				"enabled":                   true,
+				"disableContainerSelectors": true,
 			},
-			NodeAttestor:        kubernetesPsat,
-			NodeAttestorEnabled: true,
+			NodeAttestor: kubernetesPsat,
 		}
 		tp.ServerConfig = TrustProviderServerConfig{
-			NodeAttestor:        kubernetesPsat,
-			NodeAttestorEnabled: true,
+			NodeAttestor: kubernetesPsat,
 			NodeAttestorConfig: map[string]any{
-				"enabled": true,
-				// Rely on defaults?
-				"serviceAccountAllowList": []string{"spire-system:spire-agent"},
-				"audience":                []string{"spire-server"},
-				"allowedNodeLabelKeys":    []string{},
-				"allowedPodLabelKeys":     []string{},
+				"enabled":  true,
+				"audience": []string{"spire-server"},
 			},
 		}
 	default:
@@ -67,17 +57,14 @@ func (tp *TrustProvider) GetValues() error {
 }
 
 type TrustProviderAgentConfig struct {
-	WorkloadAttestor        string         `yaml:"workloadAttestor"`
-	WorkloadAttestorEnabled bool           `yaml:"workloadAttestorEnabled"`
-	WorkloadAttestorConfig  map[string]any `yaml:"workloadAttestorConfig"`
-	NodeAttestor            string         `yaml:"nodeAttestor"`
-	NodeAttestorEnabled     bool           `yaml:"nodeAttestorEnabled"`
+	WorkloadAttestor       string
+	WorkloadAttestorConfig map[string]any
+	NodeAttestor           string
 }
 
 type TrustProviderServerConfig struct {
-	NodeAttestor        string         `yaml:"nodeAttestor"`
-	NodeAttestorEnabled bool           `yaml:"nodeAttestorEnabled"`
-	NodeAttestorConfig  map[string]any `yaml:"nodeAttestorConfig"`
+	NodeAttestor       string
+	NodeAttestorConfig map[string]any
 }
 
 // GetTrustProviderKindFromProfile returns the valid kind of trust provider for the

--- a/internal/pkg/workload/workload.go
+++ b/internal/pkg/workload/workload.go
@@ -77,12 +77,15 @@ func GetRegisteredWorkloads(ctx context.Context, kubeConfig string, kubeContext 
 // GetUnregisteredWorkloads will discover workloads in a Kubernetes cluster that are not (yet) registered
 func GetUnregisteredWorkloads(ctx context.Context, kubeCfgFile string, kubeContext string, secretDiscovery bool, checkSpire bool) ([]Workload, error) {
 	// Includes the initial Kubernetes namespaces.
-	ignoredNamespaces := map[string]int{
-		"kube-node-lease":    1,
-		"kube-public":        2,
-		"kube-system":        3,
-		"local-path-storage": 4,
-		"spire":              5,
+	ignoredNamespaces := map[string]bool{
+		"kube-node-lease":    true,
+		"kube-public":        true,
+		"kube-system":        true,
+		"local-path-storage": true,
+		"spire":              true,
+		"spire-server":       true,
+		"spire-system":       true,
+		"spire-mgmt":         true,
 	}
 
 	client, err := kubeutil.NewKubeClientFromSpecifiedContext(kubeCfgFile, kubeContext)

--- a/pkg/provider/helm/helm.go
+++ b/pkg/provider/helm/helm.go
@@ -34,7 +34,8 @@ const (
 	SPIRECRDsChartName    = "spire-crds"
 	SPIRECRDsChartVersion = "0.4.0"
 
-	SPIRENamespace = "spire"
+	// Kubernetes namespace in which Helm charts and CRDs will be installed.
+	SPIREManagementNamespace = "spire-mgmt"
 )
 
 // Type assertion that HelmSPIREProvider implements the Provider interface.
@@ -261,7 +262,7 @@ func newInstall(cfg *action.Configuration, chart string, version string) *action
 	install := action.NewInstall(cfg)
 	install.Version = version
 	install.ReleaseName = chart
-	install.Namespace = SPIRENamespace
+	install.Namespace = SPIREManagementNamespace
 	install.CreateNamespace = true
 	return install
 }
@@ -308,7 +309,7 @@ func installChart(ctx context.Context, cfg *action.Configuration, client *action
 
 func newUpgrade(cfg *action.Configuration, version string) *action.Upgrade {
 	upgrade := action.NewUpgrade(cfg)
-	upgrade.Namespace = SPIRENamespace
+	upgrade.Namespace = SPIREManagementNamespace
 	upgrade.Version = version
 	upgrade.ReuseValues = true
 	return upgrade

--- a/pkg/provider/helm/values.go
+++ b/pkg/provider/helm/values.go
@@ -24,8 +24,9 @@ type globalValues struct {
 	deleteHooks                   bool
 	installAndUpgradeHooksEnabled bool
 	spireClusterName              string
-	spireCreateRecommendations    bool
 	spireJwtIssuer                string
+	spireNamespacesCreate         bool
+	spireRecommendationsEnabled   bool
 	spireTrustDomain              string
 }
 
@@ -73,8 +74,9 @@ func (g *HelmValuesGenerator) GenerateValues() (map[string]any, error) {
 
 	gv := globalValues{
 		spireClusterName:              g.trustZone.GetKubernetesCluster(),
-		spireCreateRecommendations:    true,
 		spireJwtIssuer:                g.trustZone.GetJwtIssuer(),
+		spireNamespacesCreate:         true,
+		spireRecommendationsEnabled:   true,
 		spireTrustDomain:              g.trustZone.TrustDomain,
 		installAndUpgradeHooksEnabled: false,
 		deleteHooks:                   false,
@@ -243,8 +245,11 @@ func (g *globalValues) generateValues() (map[string]any, error) {
 		"global": map[string]any{
 			"spire": map[string]any{
 				"clusterName": g.spireClusterName,
+				"namespaces": map[string]any{
+					"create": g.spireNamespacesCreate,
+				},
 				"recommendations": map[string]any{
-					"create": g.spireCreateRecommendations,
+					"enabled": g.spireRecommendationsEnabled,
 				},
 				"trustDomain": g.spireTrustDomain,
 			},

--- a/pkg/provider/helm/values.go
+++ b/pkg/provider/helm/values.go
@@ -23,11 +23,18 @@ type HelmValuesGenerator struct {
 type globalValues struct {
 	deleteHooks                   bool
 	installAndUpgradeHooksEnabled bool
+	spireCASubject                caSubject
 	spireClusterName              string
 	spireJwtIssuer                string
 	spireNamespacesCreate         bool
 	spireRecommendationsEnabled   bool
 	spireTrustDomain              string
+}
+
+type caSubject struct {
+	commonName   string
+	country      string
+	organization string
 }
 
 type spireAgentValues struct {
@@ -73,6 +80,11 @@ func (g *HelmValuesGenerator) GenerateValues() (map[string]any, error) {
 	}
 
 	gv := globalValues{
+		spireCASubject: caSubject{
+			commonName:   "cofide.io",
+			country:      "UK",
+			organization: "Cofide",
+		},
 		spireClusterName:              g.trustZone.GetKubernetesCluster(),
 		spireJwtIssuer:                g.trustZone.GetJwtIssuer(),
 		spireNamespacesCreate:         true,
@@ -244,6 +256,7 @@ func (g *globalValues) generateValues() (map[string]any, error) {
 	values := map[string]any{
 		"global": map[string]any{
 			"spire": map[string]any{
+				"caSubject":   g.spireCASubject.generateValues(),
 				"clusterName": g.spireClusterName,
 				"namespaces": map[string]any{
 					"create": g.spireNamespacesCreate,
@@ -277,6 +290,15 @@ func (g *globalValues) generateValues() (map[string]any, error) {
 	}
 
 	return values, nil
+}
+
+// generateValues generates the global.spire.caSubject Helm values map.
+func (c *caSubject) generateValues() map[string]any {
+	return map[string]any{
+		"country":      c.country,
+		"organization": c.organization,
+		"commonName":   c.commonName,
+	}
 }
 
 // generateValues generates the spire-agent Helm values map.

--- a/pkg/provider/helm/values.go
+++ b/pkg/provider/helm/values.go
@@ -38,11 +38,10 @@ type caSubject struct {
 }
 
 type spireAgentValues struct {
-	agentConfig        trustprovider.TrustProviderAgentConfig
-	fullnameOverride   string
-	logLevel           string
-	sdsConfig          map[string]any
-	spireServerAddress string
+	agentConfig      trustprovider.TrustProviderAgentConfig
+	fullnameOverride string
+	logLevel         string
+	sdsConfig        map[string]any
 }
 
 type spireServerValues struct {
@@ -105,11 +104,10 @@ func (g *HelmValuesGenerator) GenerateValues() (map[string]any, error) {
 	}
 
 	sav := spireAgentValues{
-		fullnameOverride:   "spire-agent",
-		logLevel:           "DEBUG",
-		agentConfig:        tp.AgentConfig,
-		sdsConfig:          sdsConfig,
-		spireServerAddress: "spire-server.spire-server",
+		fullnameOverride: "spire-agent",
+		logLevel:         "DEBUG",
+		agentConfig:      tp.AgentConfig,
+		sdsConfig:        sdsConfig,
 	}
 	spireAgentValues, err := sav.generateValues()
 	if err != nil {
@@ -335,23 +333,16 @@ func (s *spireAgentValues) generateValues() (map[string]any, error) {
 		return nil, fmt.Errorf("agentConfig.WorkloadAttestorConfig value is empty")
 	}
 
-	if s.spireServerAddress == "" {
-		return nil, fmt.Errorf("spireServerAddress value is empty")
-	}
-
 	return map[string]any{
 		"spire-agent": map[string]any{
 			"fullnameOverride": s.fullnameOverride,
 			"logLevel":         s.logLevel,
 			"nodeAttestor": map[string]any{
 				s.agentConfig.NodeAttestor: map[string]any{
-					"enabled": s.agentConfig.NodeAttestorEnabled,
+					"enabled": true,
 				},
 			},
 			"sds": s.sdsConfig,
-			"server": map[string]any{
-				"address": s.spireServerAddress,
-			},
 			"workloadAttestors": map[string]any{
 				s.agentConfig.WorkloadAttestor: s.agentConfig.WorkloadAttestorConfig,
 			},

--- a/pkg/provider/helm/values.go
+++ b/pkg/provider/helm/values.go
@@ -97,7 +97,7 @@ func (g *HelmValuesGenerator) GenerateValues() (map[string]any, error) {
 		logLevel:           "DEBUG",
 		agentConfig:        tp.AgentConfig,
 		sdsConfig:          sdsConfig,
-		spireServerAddress: "spire-server.spire",
+		spireServerAddress: "spire-server.spire-server",
 	}
 	spireAgentValues, err := sav.generateValues()
 	if err != nil {

--- a/pkg/provider/helm/values_test.go
+++ b/pkg/provider/helm/values_test.go
@@ -46,6 +46,11 @@ func TestHelmValuesGenerator_GenerateValues_success(t *testing.T) {
 						"enabled": false,
 					},
 					"spire": Values{
+						"caSubject": Values{
+							"commonName":   "cofide.io",
+							"country":      "UK",
+							"organization": "Cofide",
+						},
 						"clusterName": "local1",
 						"namespaces": Values{
 							"create": true,
@@ -256,6 +261,11 @@ func TestHelmValuesGenerator_GenerateValues_success(t *testing.T) {
 						"enabled": false,
 					},
 					"spire": Values{
+						"caSubject": Values{
+							"commonName":   "cofide.io",
+							"country":      "UK",
+							"organization": "Cofide",
+						},
 						"clusterName": "local4",
 						"namespaces": Values{
 							"create": true,
@@ -397,6 +407,11 @@ func TestHelmValuesGenerator_GenerateValues_AdditionalValues(t *testing.T) {
 						"enabled": false,
 					},
 					"spire": Values{
+						"caSubject": Values{
+							"commonName":   "cofide.io",
+							"country":      "UK",
+							"organization": "Cofide",
+						},
 						"clusterName": "local1",
 						"namespaces": Values{
 							"create": true,
@@ -987,6 +1002,11 @@ func TestGlobalValues_GenerateValues(t *testing.T) {
 			want: map[string]any{
 				"global": map[string]any{
 					"spire": map[string]any{
+						"caSubject": Values{
+							"commonName":   "",
+							"country":      "",
+							"organization": "",
+						},
 						"clusterName": "local1",
 						"namespaces": Values{
 							"create": false,
@@ -1016,6 +1036,11 @@ func TestGlobalValues_GenerateValues(t *testing.T) {
 			want: map[string]any{
 				"global": map[string]any{
 					"spire": map[string]any{
+						"caSubject": Values{
+							"commonName":   "",
+							"country":      "",
+							"organization": "",
+						},
 						"clusterName": "local1",
 						"namespaces": Values{
 							"create": false,
@@ -1045,6 +1070,11 @@ func TestGlobalValues_GenerateValues(t *testing.T) {
 			want: map[string]any{
 				"global": map[string]any{
 					"spire": map[string]any{
+						"caSubject": Values{
+							"commonName":   "",
+							"country":      "",
+							"organization": "",
+						},
 						"clusterName": "local1",
 						"jwtIssuer":   "https://tz1.example.com",
 						"namespaces": Values{

--- a/pkg/provider/helm/values_test.go
+++ b/pkg/provider/helm/values_test.go
@@ -77,7 +77,7 @@ func TestHelmValuesGenerator_GenerateValues_success(t *testing.T) {
 						"defaultAllBundlesName": "ALL",
 					},
 					"server": Values{
-						"address": "spire-server.spire",
+						"address": "spire-server.spire-server",
 					},
 					"workloadAttestors": Values{
 						"k8s": Values{
@@ -114,7 +114,7 @@ func TestHelmValuesGenerator_GenerateValues_success(t *testing.T) {
 							},
 							"enabled": true,
 							"serviceAccountAllowList": []string{
-								"spire:spire-agent",
+								"spire-system:spire-agent",
 							},
 						},
 					},
@@ -173,7 +173,7 @@ func TestHelmValuesGenerator_GenerateValues_success(t *testing.T) {
 						"defaultAllBundlesName": "ALL",
 					},
 					"server": Values{
-						"address": "spire-server.spire",
+						"address": "spire-server.spire-server",
 					},
 					"workloadAttestors": Values{
 						"k8s": Values{
@@ -224,6 +224,7 @@ func TestHelmValuesGenerator_GenerateValues_success(t *testing.T) {
 					},
 					"fullnameOverride": "spire-server",
 					"logLevel":         "INFO",
+					"nameOverride":     "custom-server-name",
 					"nodeAttestor": Values{
 						"k8sPsat": Values{
 							"allowedNodeLabelKeys": []string{},
@@ -233,7 +234,7 @@ func TestHelmValuesGenerator_GenerateValues_success(t *testing.T) {
 							},
 							"enabled": true,
 							"serviceAccountAllowList": []string{
-								"spire:spire-agent",
+								"spire-system:spire-agent",
 							},
 						},
 					},
@@ -286,7 +287,7 @@ func TestHelmValuesGenerator_GenerateValues_success(t *testing.T) {
 						"defaultAllBundlesName": "ROOTCA",
 					},
 					"server": Values{
-						"address": "spire-server.spire",
+						"address": "spire-server.spire-server",
 					},
 					"workloadAttestors": Values{
 						"k8s": Values{
@@ -323,7 +324,7 @@ func TestHelmValuesGenerator_GenerateValues_success(t *testing.T) {
 							},
 							"enabled": true,
 							"serviceAccountAllowList": []string{
-								"spire:spire-agent",
+								"spire-system:spire-agent",
 							},
 						},
 					},
@@ -427,7 +428,7 @@ func TestHelmValuesGenerator_GenerateValues_AdditionalValues(t *testing.T) {
 						"defaultAllBundlesName": "ALL",
 					},
 					"server": Values{
-						"address": "spire-server.spire",
+						"address": "spire-server.spire-server",
 					},
 					"workloadAttestors": Values{
 						"k8s": Values{
@@ -473,7 +474,7 @@ func TestHelmValuesGenerator_GenerateValues_AdditionalValues(t *testing.T) {
 							},
 							"enabled": true,
 							"serviceAccountAllowList": []string{
-								"spire:spire-agent",
+								"spire-system:spire-agent",
 							},
 						},
 					},
@@ -1120,7 +1121,7 @@ func TestSpireAgentValues_GenerateValues(t *testing.T) {
 					"defaultBundleName":     "ROOTCA",
 					"defaultAllBundlesName": "ALL",
 				},
-				spireServerAddress: "spire-server.spire",
+				spireServerAddress: "spire-server.spire-server",
 			},
 			want: map[string]any{
 				"spire-agent": map[string]any{
@@ -1138,7 +1139,7 @@ func TestSpireAgentValues_GenerateValues(t *testing.T) {
 						"defaultAllBundlesName": "ALL",
 					},
 					"server": map[string]any{
-						"address": "spire-server.spire",
+						"address": "spire-server.spire-server",
 					},
 					"workloadAttestors": map[string]any{
 						"k8s": map[string]any{
@@ -1176,7 +1177,7 @@ func TestSpireAgentValues_GenerateValues(t *testing.T) {
 					"defaultBundleName":     "ROOTCA",
 					"defaultAllBundlesName": "ALL",
 				},
-				spireServerAddress: "spire-server.spire",
+				spireServerAddress: "spire-server.spire-server",
 			},
 			want:      nil,
 			wantErr:   true,
@@ -1200,7 +1201,7 @@ func TestSpireAgentValues_GenerateValues(t *testing.T) {
 					"defaultBundleName":     "ROOTCA",
 					"defaultAllBundlesName": "ALL",
 				},
-				spireServerAddress: "spire-server.spire",
+				spireServerAddress: "spire-server.spire-server",
 			},
 			want:      nil,
 			wantErr:   true,
@@ -1230,7 +1231,7 @@ func TestSpireAgentValues_GenerateValues(t *testing.T) {
 					"defaultBundleName":     "ROOTCA",
 					"defaultAllBundlesName": "ALL",
 				},
-				spireServerAddress: "spire-server.spire",
+				spireServerAddress: "spire-server.spire-server",
 			},
 			want:      nil,
 			wantErr:   true,
@@ -1255,7 +1256,7 @@ func TestSpireAgentValues_GenerateValues(t *testing.T) {
 					NodeAttestorEnabled: true,
 				},
 				sdsConfig:          map[string]any{},
-				spireServerAddress: "spire-server.spire",
+				spireServerAddress: "spire-server.spire-server",
 			},
 			want:      nil,
 			wantErr:   true,
@@ -1280,7 +1281,7 @@ func TestSpireAgentValues_GenerateValues(t *testing.T) {
 					NodeAttestorEnabled: true,
 				},
 				sdsConfig:          nil,
-				spireServerAddress: "spire-server.spire",
+				spireServerAddress: "spire-server.spire-server",
 			},
 			want:      nil,
 			wantErr:   true,
@@ -1323,7 +1324,7 @@ func TestSpireServerValues_GenerateValues(t *testing.T) {
 					NodeAttestorEnabled: true,
 					NodeAttestorConfig: map[string]any{
 						"enabled":                 true,
-						"serviceAccountAllowList": []string{"spire:spire-agent"},
+						"serviceAccountAllowList": []string{"spire-system:spire-agent"},
 						"audience":                []string{"spire-server"},
 						"allowedNodeLabelKeys":    []string{},
 						"allowedPodLabelKeys":     []string{},
@@ -1350,7 +1351,7 @@ func TestSpireServerValues_GenerateValues(t *testing.T) {
 							},
 							"enabled": true,
 							"serviceAccountAllowList": []string{
-								"spire:spire-agent",
+								"spire-system:spire-agent",
 							},
 						},
 					},
@@ -1387,7 +1388,7 @@ func TestSpireServerValues_GenerateValues(t *testing.T) {
 					NodeAttestorEnabled: true,
 					NodeAttestorConfig: map[string]any{
 						"enabled":                 true,
-						"serviceAccountAllowList": []string{"spire:spire-agent"},
+						"serviceAccountAllowList": []string{"spire-system:spire-agent"},
 						"audience":                []string{"spire-server"},
 						"allowedNodeLabelKeys":    []string{},
 						"allowedPodLabelKeys":     []string{},

--- a/pkg/provider/helm/values_test.go
+++ b/pkg/provider/helm/values_test.go
@@ -47,8 +47,11 @@ func TestHelmValuesGenerator_GenerateValues_success(t *testing.T) {
 					},
 					"spire": Values{
 						"clusterName": "local1",
-						"recommendations": Values{
+						"namespaces": Values{
 							"create": true,
+						},
+						"recommendations": Values{
+							"enabled": true,
 						},
 						"trustDomain": "td1",
 					},
@@ -133,13 +136,18 @@ func TestHelmValuesGenerator_GenerateValues_success(t *testing.T) {
 						"enabled": false,
 					},
 					"spire": Values{
+						"caSubject": Values{
+							"country":      "UK",
+							"organization": "acme-org",
+							"commonName":   "cn.example.com",
+						},
 						"clusterName": "local1",
 						"jwtIssuer":   "https://tz1.example.com",
 						"namespaces": Values{
 							"create": true,
 						},
 						"recommendations": Values{
-							"create": true,
+							"enabled": true,
 						},
 						"trustDomain": "td1",
 					},
@@ -248,8 +256,11 @@ func TestHelmValuesGenerator_GenerateValues_success(t *testing.T) {
 					},
 					"spire": Values{
 						"clusterName": "local4",
-						"recommendations": Values{
+						"namespaces": Values{
 							"create": true,
+						},
+						"recommendations": Values{
+							"enabled": true,
 						},
 						"trustDomain": "td4",
 					},
@@ -386,8 +397,11 @@ func TestHelmValuesGenerator_GenerateValues_AdditionalValues(t *testing.T) {
 					},
 					"spire": Values{
 						"clusterName": "local1",
-						"recommendations": Values{
+						"namespaces": Values{
 							"create": true,
+						},
+						"recommendations": Values{
+							"enabled": true,
 						},
 						"trustDomain": "td1",
 					},
@@ -973,8 +987,11 @@ func TestGlobalValues_GenerateValues(t *testing.T) {
 				"global": map[string]any{
 					"spire": map[string]any{
 						"clusterName": "local1",
-						"recommendations": map[string]any{
+						"namespaces": Values{
 							"create": false,
+						},
+						"recommendations": map[string]any{
+							"enabled": false,
 						},
 						"trustDomain": "td1",
 					},
@@ -999,8 +1016,11 @@ func TestGlobalValues_GenerateValues(t *testing.T) {
 				"global": map[string]any{
 					"spire": map[string]any{
 						"clusterName": "local1",
-						"recommendations": map[string]any{
+						"namespaces": Values{
 							"create": false,
+						},
+						"recommendations": map[string]any{
+							"enabled": false,
 						},
 						"trustDomain": "td1",
 					},
@@ -1026,8 +1046,11 @@ func TestGlobalValues_GenerateValues(t *testing.T) {
 					"spire": map[string]any{
 						"clusterName": "local1",
 						"jwtIssuer":   "https://tz1.example.com",
-						"recommendations": map[string]any{
+						"namespaces": Values{
 							"create": false,
+						},
+						"recommendations": map[string]any{
+							"enabled": false,
 						},
 						"trustDomain": "td1",
 					},

--- a/pkg/provider/helm/values_test.go
+++ b/pkg/provider/helm/values_test.go
@@ -81,16 +81,10 @@ func TestHelmValuesGenerator_GenerateValues_success(t *testing.T) {
 						"defaultBundleName":     "ROOTCA",
 						"defaultAllBundlesName": "ALL",
 					},
-					"server": Values{
-						"address": "spire-server.spire-server",
-					},
 					"workloadAttestors": Values{
 						"k8s": Values{
-							"disableContainerSelectors":   true,
-							"enabled":                     true,
-							"skipKubeletVerification":     true,
-							"useNewContainerLocator":      false,
-							"verboseContainerLocatorLogs": false,
+							"disableContainerSelectors": true,
+							"enabled":                   true,
 						},
 					},
 				},
@@ -112,15 +106,8 @@ func TestHelmValuesGenerator_GenerateValues_success(t *testing.T) {
 					"logLevel":         "DEBUG",
 					"nodeAttestor": Values{
 						"k8sPsat": Values{
-							"allowedNodeLabelKeys": []string{},
-							"allowedPodLabelKeys":  []string{},
-							"audience": []string{
-								"spire-server",
-							},
-							"enabled": true,
-							"serviceAccountAllowList": []string{
-								"spire-system:spire-agent",
-							},
+							"audience": []string{"spire-server"},
+							"enabled":  true,
 						},
 					},
 					"service": Values{
@@ -177,16 +164,10 @@ func TestHelmValuesGenerator_GenerateValues_success(t *testing.T) {
 						"defaultBundleName":     "ROOTCA",
 						"defaultAllBundlesName": "ALL",
 					},
-					"server": Values{
-						"address": "spire-server.spire-server",
-					},
 					"workloadAttestors": Values{
 						"k8s": Values{
-							"disableContainerSelectors":   true,
-							"enabled":                     true,
-							"skipKubeletVerification":     true,
-							"useNewContainerLocator":      false,
-							"verboseContainerLocatorLogs": false,
+							"disableContainerSelectors": true,
+							"enabled":                   true,
 						},
 					},
 				},
@@ -232,15 +213,8 @@ func TestHelmValuesGenerator_GenerateValues_success(t *testing.T) {
 					"nameOverride":     "custom-server-name",
 					"nodeAttestor": Values{
 						"k8sPsat": Values{
-							"allowedNodeLabelKeys": []string{},
-							"allowedPodLabelKeys":  []string{},
-							"audience": []string{
-								"spire-server",
-							},
-							"enabled": true,
-							"serviceAccountAllowList": []string{
-								"spire-system:spire-agent",
-							},
+							"audience": []string{"spire-server"},
+							"enabled":  true,
 						},
 					},
 					"service": Values{
@@ -296,16 +270,10 @@ func TestHelmValuesGenerator_GenerateValues_success(t *testing.T) {
 						"defaultBundleName":     "null",
 						"defaultAllBundlesName": "ROOTCA",
 					},
-					"server": Values{
-						"address": "spire-server.spire-server",
-					},
 					"workloadAttestors": Values{
 						"k8s": Values{
-							"disableContainerSelectors":   true,
-							"enabled":                     true,
-							"skipKubeletVerification":     true,
-							"useNewContainerLocator":      false,
-							"verboseContainerLocatorLogs": false,
+							"disableContainerSelectors": true,
+							"enabled":                   true,
 						},
 					},
 				},
@@ -327,15 +295,8 @@ func TestHelmValuesGenerator_GenerateValues_success(t *testing.T) {
 					"logLevel":         "DEBUG",
 					"nodeAttestor": Values{
 						"k8sPsat": Values{
-							"allowedNodeLabelKeys": []string{},
-							"allowedPodLabelKeys":  []string{},
-							"audience": []string{
-								"spire-server",
-							},
-							"enabled": true,
-							"serviceAccountAllowList": []string{
-								"spire-system:spire-agent",
-							},
+							"audience": []string{"spire-server"},
+							"enabled":  true,
 						},
 					},
 					"service": Values{
@@ -442,16 +403,10 @@ func TestHelmValuesGenerator_GenerateValues_AdditionalValues(t *testing.T) {
 						"defaultBundleName":     "ROOTCA",
 						"defaultAllBundlesName": "ALL",
 					},
-					"server": Values{
-						"address": "spire-server.spire-server",
-					},
 					"workloadAttestors": Values{
 						"k8s": Values{
-							"disableContainerSelectors":   true,
-							"enabled":                     true,
-							"skipKubeletVerification":     true,
-							"useNewContainerLocator":      false,
-							"verboseContainerLocatorLogs": false,
+							"disableContainerSelectors": true,
+							"enabled":                   true,
 						},
 					},
 				},
@@ -482,15 +437,8 @@ func TestHelmValuesGenerator_GenerateValues_AdditionalValues(t *testing.T) {
 					"logLevel":         "DEBUG",
 					"nodeAttestor": Values{
 						"k8sPsat": Values{
-							"allowedNodeLabelKeys": []string{},
-							"allowedPodLabelKeys":  []string{},
-							"audience": []string{
-								"spire-server",
-							},
-							"enabled": true,
-							"serviceAccountAllowList": []string{
-								"spire-system:spire-agent",
-							},
+							"audience": []string{"spire-server"},
+							"enabled":  true,
 						},
 					},
 					"service": Values{
@@ -1133,17 +1081,12 @@ func TestSpireAgentValues_GenerateValues(t *testing.T) {
 				fullnameOverride: "spire-agent",
 				logLevel:         "DEBUG",
 				agentConfig: trustprovider.TrustProviderAgentConfig{
-					WorkloadAttestor:        "k8s",
-					WorkloadAttestorEnabled: true,
+					WorkloadAttestor: "k8s",
 					WorkloadAttestorConfig: map[string]any{
-						"enabled":                     true,
-						"skipKubeletVerification":     true,
-						"disableContainerSelectors":   true,
-						"useNewContainerLocator":      false,
-						"verboseContainerLocatorLogs": false,
+						"enabled":                   true,
+						"disableContainerSelectors": true,
 					},
-					NodeAttestor:        "k8sPsat",
-					NodeAttestorEnabled: true,
+					NodeAttestor: "k8sPsat",
 				},
 				sdsConfig: map[string]any{
 					"enabled":               true,
@@ -1151,7 +1094,6 @@ func TestSpireAgentValues_GenerateValues(t *testing.T) {
 					"defaultBundleName":     "ROOTCA",
 					"defaultAllBundlesName": "ALL",
 				},
-				spireServerAddress: "spire-server.spire-server",
 			},
 			want: map[string]any{
 				"spire-agent": map[string]any{
@@ -1168,16 +1110,10 @@ func TestSpireAgentValues_GenerateValues(t *testing.T) {
 						"defaultBundleName":     "ROOTCA",
 						"defaultAllBundlesName": "ALL",
 					},
-					"server": map[string]any{
-						"address": "spire-server.spire-server",
-					},
 					"workloadAttestors": map[string]any{
 						"k8s": map[string]any{
-							"enabled":                     true,
-							"skipKubeletVerification":     true,
-							"disableContainerSelectors":   true,
-							"useNewContainerLocator":      false,
-							"verboseContainerLocatorLogs": false,
+							"enabled":                   true,
+							"disableContainerSelectors": true,
 						},
 					},
 				},
@@ -1189,17 +1125,12 @@ func TestSpireAgentValues_GenerateValues(t *testing.T) {
 			input: spireAgentValues{
 				fullnameOverride: "spire-agent",
 				agentConfig: trustprovider.TrustProviderAgentConfig{
-					WorkloadAttestor:        "k8s",
-					WorkloadAttestorEnabled: true,
+					WorkloadAttestor: "k8s",
 					WorkloadAttestorConfig: map[string]any{
-						"enabled":                     true,
-						"skipKubeletVerification":     true,
-						"disableContainerSelectors":   true,
-						"useNewContainerLocator":      false,
-						"verboseContainerLocatorLogs": false,
+						"enabled":                   true,
+						"disableContainerSelectors": true,
 					},
-					NodeAttestor:        "k8sPsat",
-					NodeAttestorEnabled: true,
+					NodeAttestor: "k8sPsat",
 				},
 				sdsConfig: map[string]any{
 					"enabled":               true,
@@ -1207,7 +1138,6 @@ func TestSpireAgentValues_GenerateValues(t *testing.T) {
 					"defaultBundleName":     "ROOTCA",
 					"defaultAllBundlesName": "ALL",
 				},
-				spireServerAddress: "spire-server.spire-server",
 			},
 			want:      nil,
 			wantErr:   true,
@@ -1219,11 +1149,9 @@ func TestSpireAgentValues_GenerateValues(t *testing.T) {
 				fullnameOverride: "spire-agent",
 				logLevel:         "DEBUG",
 				agentConfig: trustprovider.TrustProviderAgentConfig{
-					WorkloadAttestor:        "k8s",
-					WorkloadAttestorEnabled: true,
-					WorkloadAttestorConfig:  map[string]any{},
-					NodeAttestor:            "k8sPsat",
-					NodeAttestorEnabled:     true,
+					WorkloadAttestor:       "k8s",
+					WorkloadAttestorConfig: map[string]any{},
+					NodeAttestor:           "k8sPsat",
 				},
 				sdsConfig: map[string]any{
 					"enabled":               true,
@@ -1231,7 +1159,6 @@ func TestSpireAgentValues_GenerateValues(t *testing.T) {
 					"defaultBundleName":     "ROOTCA",
 					"defaultAllBundlesName": "ALL",
 				},
-				spireServerAddress: "spire-server.spire-server",
 			},
 			want:      nil,
 			wantErr:   true,
@@ -1243,17 +1170,12 @@ func TestSpireAgentValues_GenerateValues(t *testing.T) {
 				fullnameOverride: "spire-agent",
 				logLevel:         "DEBUG",
 				agentConfig: trustprovider.TrustProviderAgentConfig{
-					WorkloadAttestor:        "",
-					WorkloadAttestorEnabled: true,
+					WorkloadAttestor: "",
 					WorkloadAttestorConfig: map[string]any{
-						"enabled":                     true,
-						"skipKubeletVerification":     true,
-						"disableContainerSelectors":   true,
-						"useNewContainerLocator":      false,
-						"verboseContainerLocatorLogs": false,
+						"enabled":                   true,
+						"disableContainerSelectors": true,
 					},
-					NodeAttestor:        "k8sPsat",
-					NodeAttestorEnabled: true,
+					NodeAttestor: "k8sPsat",
 				},
 				sdsConfig: map[string]any{
 					"enabled":               true,
@@ -1261,7 +1183,6 @@ func TestSpireAgentValues_GenerateValues(t *testing.T) {
 					"defaultBundleName":     "ROOTCA",
 					"defaultAllBundlesName": "ALL",
 				},
-				spireServerAddress: "spire-server.spire-server",
 			},
 			want:      nil,
 			wantErr:   true,
@@ -1273,20 +1194,14 @@ func TestSpireAgentValues_GenerateValues(t *testing.T) {
 				fullnameOverride: "spire-agent",
 				logLevel:         "DEBUG",
 				agentConfig: trustprovider.TrustProviderAgentConfig{
-					WorkloadAttestor:        "",
-					WorkloadAttestorEnabled: true,
+					WorkloadAttestor: "",
 					WorkloadAttestorConfig: map[string]any{
-						"enabled":                     true,
-						"skipKubeletVerification":     true,
-						"disableContainerSelectors":   true,
-						"useNewContainerLocator":      false,
-						"verboseContainerLocatorLogs": false,
+						"enabled":                   true,
+						"disableContainerSelectors": true,
 					},
-					NodeAttestor:        "k8sPsat",
-					NodeAttestorEnabled: true,
+					NodeAttestor: "k8sPsat",
 				},
-				sdsConfig:          map[string]any{},
-				spireServerAddress: "spire-server.spire-server",
+				sdsConfig: map[string]any{},
 			},
 			want:      nil,
 			wantErr:   true,
@@ -1298,20 +1213,14 @@ func TestSpireAgentValues_GenerateValues(t *testing.T) {
 				fullnameOverride: "spire-agent",
 				logLevel:         "DEBUG",
 				agentConfig: trustprovider.TrustProviderAgentConfig{
-					WorkloadAttestor:        "",
-					WorkloadAttestorEnabled: true,
+					WorkloadAttestor: "",
 					WorkloadAttestorConfig: map[string]any{
-						"enabled":                     true,
-						"skipKubeletVerification":     true,
-						"disableContainerSelectors":   true,
-						"useNewContainerLocator":      false,
-						"verboseContainerLocatorLogs": false,
+						"enabled":                   true,
+						"disableContainerSelectors": true,
 					},
-					NodeAttestor:        "k8sPsat",
-					NodeAttestorEnabled: true,
+					NodeAttestor: "k8sPsat",
 				},
-				sdsConfig:          nil,
-				spireServerAddress: "spire-server.spire-server",
+				sdsConfig: nil,
 			},
 			want:      nil,
 			wantErr:   true,
@@ -1350,14 +1259,10 @@ func TestSpireServerValues_GenerateValues(t *testing.T) {
 				fullnameOverride:         "spire-server",
 				logLevel:                 "DEBUG",
 				serverConfig: trustprovider.TrustProviderServerConfig{
-					NodeAttestor:        "k8sPsat",
-					NodeAttestorEnabled: true,
+					NodeAttestor: "k8sPsat",
 					NodeAttestorConfig: map[string]any{
-						"enabled":                 true,
-						"serviceAccountAllowList": []string{"spire-system:spire-agent"},
-						"audience":                []string{"spire-server"},
-						"allowedNodeLabelKeys":    []string{},
-						"allowedPodLabelKeys":     []string{},
+						"enabled":  true,
+						"audience": []string{"spire-server"},
 					},
 				},
 				serviceType: "LoadBalancer",
@@ -1374,15 +1279,8 @@ func TestSpireServerValues_GenerateValues(t *testing.T) {
 					"logLevel":         "DEBUG",
 					"nodeAttestor": Values{
 						"k8sPsat": Values{
-							"allowedNodeLabelKeys": []string{},
-							"allowedPodLabelKeys":  []string{},
-							"audience": []string{
-								"spire-server",
-							},
-							"enabled": true,
-							"serviceAccountAllowList": []string{
-								"spire-system:spire-agent",
-							},
+							"audience": []string{"spire-server"},
+							"enabled":  true,
 						},
 					},
 					"service": map[string]any{
@@ -1414,14 +1312,11 @@ func TestSpireServerValues_GenerateValues(t *testing.T) {
 				fullnameOverride:         "spire-server",
 				logLevel:                 "DEBUG",
 				serverConfig: trustprovider.TrustProviderServerConfig{
-					NodeAttestor:        "k8sPsat",
-					NodeAttestorEnabled: true,
+					NodeAttestor: "k8sPsat",
+					//NodeAttestorEnabled: true,
 					NodeAttestorConfig: map[string]any{
-						"enabled":                 true,
-						"serviceAccountAllowList": []string{"spire-system:spire-agent"},
-						"audience":                []string{"spire-server"},
-						"allowedNodeLabelKeys":    []string{},
-						"allowedPodLabelKeys":     []string{},
+						"enabled":  true,
+						"audience": []string{"spire-server"},
 					},
 				},
 				serviceType: "",
@@ -1440,9 +1335,9 @@ func TestSpireServerValues_GenerateValues(t *testing.T) {
 				fullnameOverride:         "spire-server",
 				logLevel:                 "DEBUG",
 				serverConfig: trustprovider.TrustProviderServerConfig{
-					NodeAttestor:        "k8sPsat",
-					NodeAttestorEnabled: true,
-					NodeAttestorConfig:  map[string]any{},
+					NodeAttestor: "k8sPsat",
+					//NodeAttestorEnabled: true,
+					NodeAttestorConfig: map[string]any{},
 				},
 				serviceType: "",
 			},

--- a/pkg/spire/spire_server_cli.go
+++ b/pkg/spire/spire_server_cli.go
@@ -35,7 +35,7 @@ func execInServerContainer(ctx context.Context, client *kubeutil.Client, command
 		client.Clientset,
 		client.RestConfig,
 		serverPodName,
-		namespace,
+		serverNamespace,
 		serverContainerName,
 		command,
 		stdin,

--- a/pkg/spire/spire_server_cli_test.go
+++ b/pkg/spire/spire_server_cli_test.go
@@ -35,7 +35,7 @@ var oneAgentList = `{
         },
         {
           "type": "k8s_psat",
-          "value": "agent_ns:spire"
+          "value": "agent_ns:spire-system"
         },
         {
           "type": "k8s_psat",

--- a/pkg/spire/spire_test.go
+++ b/pkg/spire/spire_test.go
@@ -36,7 +36,7 @@ func TestGetServerStatus(t *testing.T) {
 			),
 		)
 	_, err := clientSet.AppsV1().
-		StatefulSets("spire").
+		StatefulSets("spire-server").
 		Apply(ctx, ssConfig, metav1.ApplyOptions{})
 	if err != nil {
 		t.Fatalf("failed to create statefulset: %v", err)
@@ -59,7 +59,7 @@ func TestGetServerStatus(t *testing.T) {
 			),
 		)
 	_, err = clientSet.CoreV1().
-		Pods("spire").
+		Pods("spire-server").
 		Apply(ctx, podConfig, metav1.ApplyOptions{})
 	if err != nil {
 		t.Fatalf("failed to create pod: %v", err)
@@ -104,7 +104,7 @@ func Test_addAgentK8sStatus(t *testing.T) {
 			WithNumberReady(1),
 		)
 	_, err := clientSet.AppsV1().
-		DaemonSets("spire").
+		DaemonSets("spire-system").
 		Apply(ctx, dsConfig, metav1.ApplyOptions{})
 	if err != nil {
 		t.Fatalf("failed to create daemonset: %v", err)
@@ -125,7 +125,7 @@ func Test_addAgentK8sStatus(t *testing.T) {
 			),
 		)
 	_, err = clientSet.CoreV1().
-		Pods("spire").
+		Pods("spire-system").
 		Apply(ctx, podConfig, metav1.ApplyOptions{})
 	if err != nil {
 		t.Fatalf("failed to create pod: %v", err)
@@ -146,7 +146,7 @@ func Test_addAgentK8sStatus(t *testing.T) {
 			),
 		)
 	_, err = clientSet.CoreV1().
-		Pods("spire").
+		Pods("spire-system").
 		Apply(ctx, podConfig, metav1.ApplyOptions{})
 	if err != nil {
 		t.Fatalf("failed to create pod: %v", err)

--- a/tests/integration/federation/test.sh
+++ b/tests/integration/federation/test.sh
@@ -140,9 +140,9 @@ function show_workload_status() {
 }
 
 function teardown_federation_and_verify() {
-  kubectl --context $K8S_CLUSTER_2_CONTEXT delete clusterspiffeids.spire.spiffe.io spire-spire-namespace
-  kubectl exec --context $K8S_CLUSTER_2_CONTEXT -n spire spire-server-0 -- /opt/spire/bin/spire-server federation delete -id td1
-  kubectl exec --context $K8S_CLUSTER_2_CONTEXT -n spire spire-server-0 -- /opt/spire/bin/spire-server bundle delete -id td1
+  kubectl --context $K8S_CLUSTER_2_CONTEXT delete clusterspiffeids.spire.spiffe.io spire-mgmt-spire-namespace
+  kubectl exec --context $K8S_CLUSTER_2_CONTEXT -n spire-server spire-server-0 -- /opt/spire/bin/spire-server federation delete -id td1
+  kubectl exec --context $K8S_CLUSTER_2_CONTEXT -n spire-server spire-server-0 -- /opt/spire/bin/spire-server bundle delete -id td1
   federations=$(./cofidectl federation list)
   if ! echo "$federations" | grep "Unhealthy | No bundle found" >/dev/null; then
     return 1

--- a/tests/integration/federation/test.sh
+++ b/tests/integration/federation/test.sh
@@ -5,6 +5,8 @@
 
 set -euxo pipefail
 
+source $(dirname $(dirname $BASH_SOURCE))/lib.sh
+
 DATA_SOURCE_PLUGIN=${DATA_SOURCE_PLUGIN:-}
 PROVISION_PLUGIN=${PROVISION_PLUGIN:-}
 
@@ -63,6 +65,14 @@ function configure() {
 
 function up() {
   ./cofidectl up
+}
+
+function check_spire() {
+  for context in $K8S_CLUSTER_1_CONTEXT $K8S_CLUSTER_2_CONTEXT; do
+    check_spire_server $context
+    check_spire_agents $context
+    check_spire_csi_driver $context
+  done
 }
 
 function list_resources() {
@@ -139,6 +149,7 @@ function main() {
   check_init
   configure
   up
+  check_spire
   list_resources
   show_config
   show_status

--- a/tests/integration/lib.sh
+++ b/tests/integration/lib.sh
@@ -1,0 +1,25 @@
+# This file provides common library functions for use by integration tests.
+
+function check_spire_server() {
+  local context=${1:?Spire server k8s context}
+  if ! kubectl --context $context -n spire-server get statefulsets spire-server; then
+    echo "Server statefulset not found"
+    return 1
+  fi
+}
+
+function check_spire_agents() {
+  local context=${1:?Spire agent k8s context}
+  if ! kubectl --context $context -n spire-system get daemonsets spire-agent; then
+    echo "Agent daemonset not found"
+    return 1
+  fi
+}
+
+function check_spire_csi_driver() {
+  local context=${1:?Spire CSI k8s context}
+  if ! kubectl --context $context -n spire-system get csidrivers.storage.k8s.io csi.spiffe.io; then
+    echo "CSI driver not found"
+    return 1
+  fi
+}

--- a/tests/integration/single-trust-zone/test.sh
+++ b/tests/integration/single-trust-zone/test.sh
@@ -5,6 +5,8 @@
 
 set -euxo pipefail
 
+source $(dirname $(dirname $BASH_SOURCE))/lib.sh
+
 DATA_SOURCE_PLUGIN=${DATA_SOURCE_PLUGIN:-}
 PROVISION_PLUGIN=${PROVISION_PLUGIN:-}
 
@@ -39,6 +41,12 @@ function configure() {
 
 function up() {
   ./cofidectl up --quiet
+}
+
+function check_spire() {
+  check_spire_server $K8S_CLUSTER_CONTEXT
+  check_spire_agents $K8S_CLUSTER_CONTEXT
+  check_spire_csi_driver $K8S_CLUSTER_CONTEXT
 }
 
 function list_resources() {
@@ -106,6 +114,7 @@ function main() {
   init
   configure
   up
+  check_spire
   list_resources
   show_config
   show_status


### PR DESCRIPTION
Setting the Helm chart recommendations enabled flag applies various
changes to the configuration, as described in [1]:

- 2 namespace layout (spire-server & spire-system)
- Namespace pod security standards
- Priority class name
- Prometheus
- Strict mode
- Security contexts

We also use a 3rd namespace for the Helm chart state and CRDs as
described in [2].

[1] https://spiffe.io/docs/latest/spire-helm-charts-hardened-about/recommendations/
[2] https://spiffe.io/docs/latest/spire-helm-charts-hardened-about/namespaces/

Fixes: #113
Fixes: #114
