### PR TITLE
CI: Enable race detector when running Go tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,5 +37,5 @@ jobs:
       - name: Install dependencies
         run: |
           go mod download
-      - name: Build and run tests
-        run: just test
+      - name: Build and run tests with race detector enabled
+        run: just test-race

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,6 @@ on:
     branches:
       - main
   pull_request:
-    types: [opened, synchronize, reopened, labeled, unlabeled]
 
 jobs:
   lint:
@@ -23,7 +22,7 @@ jobs:
           args: --timeout=5m
 
   build-test:
-    name: build
+    name: test
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -1,7 +1,6 @@
 name: govulncheck
 on: 
   pull_request:
-    types: [opened, synchronize, reopened, labeled, unlabeled]
   schedule:
     - cron: '0 0 * * *'
 

--- a/Justfile
+++ b/Justfile
@@ -8,8 +8,10 @@ install-test-plugin: build-test-plugin
     mkdir -p ~/.cofide/plugins
     cp cofidectl-test-plugin ~/.cofide/plugins
 
-test:
-    go run gotest.tools/gotestsum@latest --format github-actions ./...
+test *args:
+    go run gotest.tools/gotestsum@latest --format github-actions ./... {{args}}
+
+test-race: (test "--" "-race")
 
 lint *args:
     golangci-lint run --show-stats {{args}}


### PR DESCRIPTION
- **CI: Run Go tests with race detector enabled**
- **Don't run pull request workflow on labeled/unlabeled events**
