### PR TITLE
Refactor SpireHelm to use a SPIREAPI interface

### DIFF
--- a/cmd/cofidectl-test-plugin/main.go
+++ b/cmd/cofidectl-test-plugin/main.go
@@ -59,7 +59,7 @@ func serveDataSource() error {
 	if err != nil {
 		return err
 	}
-	spireHelm := spirehelm.NewSpireHelm(nil)
+	spireHelm := spirehelm.NewSpireHelm(nil, nil)
 
 	go_plugin.Serve(&go_plugin.ServeConfig{
 		HandshakeConfig: plugin.HandshakeConfig,

--- a/pkg/plugin/manager/manager.go
+++ b/pkg/plugin/manager/manager.go
@@ -176,7 +176,7 @@ func (pm *PluginManager) loadProvision(ctx context.Context) (provision.Provision
 
 	// Check if an in-process provision implementation has been requested.
 	if provisionName == SpireHelmProvisionPluginName {
-		spireHelm := spirehelm.NewSpireHelm(nil)
+		spireHelm := spirehelm.NewSpireHelm(nil, nil)
 		if err := spireHelm.Validate(ctx); err != nil {
 			return nil, err
 		}

--- a/pkg/plugin/manager/manager_test.go
+++ b/pkg/plugin/manager/manager_test.go
@@ -302,7 +302,7 @@ func TestManager_GetProvision_success(t *testing.T) {
 		{
 			name:   "defaults",
 			config: config.Config{Plugins: GetDefaultPlugins()},
-			want:   spirehelm.NewSpireHelm(nil),
+			want:   spirehelm.NewSpireHelm(nil, nil),
 		},
 		{
 			name:   "gRPC",

--- a/pkg/plugin/provision/spirehelm/spireapi.go
+++ b/pkg/plugin/provision/spirehelm/spireapi.go
@@ -1,0 +1,55 @@
+// Copyright 2025 Cofide Limited.
+// SPDX-License-Identifier: Apache-2.0
+
+package spirehelm
+
+import (
+	"context"
+
+	kubeutil "github.com/cofide/cofidectl/pkg/kube"
+	"github.com/cofide/cofidectl/pkg/spire"
+)
+
+// Type check that SPIREAPIFactoryImpl implements the SPIREAPIFactory interface.
+var _ SPIREAPIFactory = &SPIREAPIFactoryImpl{}
+
+// SPIREAPIFactory is an interface that abstracts the construction of SPIREAPI objects.
+type SPIREAPIFactory interface {
+	// Build returns a SPIREAPI.
+	Build(kubeCfgFile, kubeContext string) (SPIREAPI, error)
+}
+
+// SPIREAPI is an interface that abstracts a subset of the SPIRE server API for use by the SpireHelm plugin.
+type SPIREAPI interface {
+	// WaitForServerIP waits for a SPIRE server pod and service to become ready, then returns the external IP of the service.
+	WaitForServerIP(ctx context.Context) (string, error)
+
+	// GetBundle retrieves a SPIFFE bundle for the local trust zone.
+	GetBundle(ctx context.Context) (string, error)
+}
+
+// SPIREAPIFactoryImpl implements the SPIREAPIFactory interface, building a SPIREAPIImpl.
+type SPIREAPIFactoryImpl struct{}
+
+func (f *SPIREAPIFactoryImpl) Build(kubeCfgFile, kubeContext string) (SPIREAPI, error) {
+	client, err := kubeutil.NewKubeClientFromSpecifiedContext(kubeCfgFile, kubeContext)
+	if err != nil {
+		return nil, err
+	}
+
+	return &SPIREAPIImpl{client: client}, nil
+}
+
+// SPIREAPIImpl implements the SPIREAPI interface using the Kubernetes API to interact with a
+// SPIRE server.
+type SPIREAPIImpl struct {
+	client *kubeutil.Client
+}
+
+func (s *SPIREAPIImpl) WaitForServerIP(ctx context.Context) (string, error) {
+	return spire.WaitForServerIP(ctx, s.client)
+}
+
+func (s *SPIREAPIImpl) GetBundle(ctx context.Context) (string, error) {
+	return spire.GetBundle(ctx, s.client)
+}


### PR DESCRIPTION
This allows for better unit testing with a fake SPIRE API.
