### PR TITLE
fix: gh release upload path doesn't match build output

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Upload artifacts
         run: |
           gh release list --limit 1 | grep -q ${{ github.ref_name }} || gh release create ${{ github.ref_name }} -d
-          gh release upload ${{ github.ref_name }} dist/cofidectl-${{ matrix.goos }}-${{ matrix.goarch }} --clobber
+          gh release upload ${{ github.ref_name }} dist/cofidectl-${{ matrix.goos }}-${{ matrix.goarch }}-${{ github.ref_name }} --clobber
           gh release upload ${{ github.ref_name }} LICENSE --clobber
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
In the test release for 6.0.1, the workflow failed to upload artifacts: https://github.com/cofide/cofidectl/actions/runs/13201616037/job/36854773746