### PR TITLE
feat: Add --no-cluster argument to trust-zone add command

### DIFF
--- a/cmd/cofidectl/cmd/federation/federation.go
+++ b/cmd/cofidectl/cmd/federation/federation.go
@@ -5,6 +5,7 @@ package federation
 
 import (
 	"context"
+	"errors"
 	"os"
 
 	clusterpb "github.com/cofide/cofide-api-sdk/gen/go/proto/cluster/v1alpha1"
@@ -133,6 +134,9 @@ func checkFederationStatus(ctx context.Context, ds datasource.DataSource, kubeCo
 	for _, tz := range []*trust_zone_proto.TrustZone{from, to} {
 		cluster, err := trustzone.GetClusterFromTrustZone(tz, ds)
 		if err != nil {
+			if errors.Is(err, trustzone.ErrNoClustersInTrustZone) {
+				return "No cluster", "N/A", nil
+			}
 			return "", "", err
 		}
 

--- a/cmd/cofidectl/cmd/workload/workload.go
+++ b/cmd/cofidectl/cmd/workload/workload.go
@@ -5,6 +5,7 @@ package workload
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 
@@ -197,6 +198,9 @@ func renderRegisteredWorkloads(ctx context.Context, ds datasource.DataSource, ku
 	for _, trustZone := range trustZones {
 		cluster, err := trustzone.GetClusterFromTrustZone(trustZone, ds)
 		if err != nil {
+			if errors.Is(err, trustzone.ErrNoClustersInTrustZone) {
+				continue
+			}
 			return err
 		}
 
@@ -315,6 +319,9 @@ func renderUnregisteredWorkloads(ctx context.Context, ds datasource.DataSource, 
 	for _, trustZone := range trustZones {
 		cluster, err := trustzone.GetClusterFromTrustZone(trustZone, ds)
 		if err != nil {
+			if errors.Is(err, trustzone.ErrNoClustersInTrustZone) {
+				continue
+			}
 			return err
 		}
 

--- a/internal/pkg/trustzone/trustzone.go
+++ b/internal/pkg/trustzone/trustzone.go
@@ -4,11 +4,16 @@
 package trustzone
 
 import (
-	"fmt"
+	"errors"
 
 	clusterpb "github.com/cofide/cofide-api-sdk/gen/go/proto/cluster/v1alpha1"
 	trust_zone_proto "github.com/cofide/cofide-api-sdk/gen/go/proto/trust_zone/v1alpha1"
 	"github.com/cofide/cofidectl/pkg/plugin/datasource"
+)
+
+var (
+	ErrNoClustersInTrustZone  = errors.New("no clusters in trust zone")
+	ErrOneClusterPerTrustZone = errors.New("expected exactly one cluster per trust zone")
 )
 
 // GetClusterFromTrustZone returns a cluster from a trust zone.
@@ -19,8 +24,11 @@ func GetClusterFromTrustZone(trustZone *trust_zone_proto.TrustZone, ds datasourc
 		return nil, err
 	}
 
-	if clusters == nil || len(clusters) != 1 {
-		return nil, fmt.Errorf("expected exactly one cluster per trust zone")
+	if len(clusters) < 1 {
+		return nil, ErrNoClustersInTrustZone
+	}
+	if len(clusters) > 1 {
+		return nil, ErrOneClusterPerTrustZone
 	}
 	return clusters[0], nil
 }

--- a/pkg/plugin/provision/spirehelm/spirehelm.go
+++ b/pkg/plugin/provision/spirehelm/spirehelm.go
@@ -5,6 +5,7 @@ package spirehelm
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	clusterpb "github.com/cofide/cofide-api-sdk/gen/go/proto/cluster/v1alpha1"
@@ -135,6 +136,9 @@ func (h *SpireHelm) ListTrustZoneClusters(ds datasource.DataSource) ([]TrustZone
 		// Sanity check that the trust zone has exactly one cluster.
 		cluster, err := trustzone.GetClusterFromTrustZone(trustZone, ds)
 		if err != nil {
+			if errors.Is(err, trustzone.ErrNoClustersInTrustZone) {
+				continue
+			}
 			return nil, err
 		}
 		trustZoneCluster := TrustZoneCluster{TrustZone: trustZone, Cluster: cluster}


### PR DESCRIPTION
This allows for creation of trust zones without an associated cluster.

Fixes: #162
