### PR TITLE
fix: change pre-release-binaries workflow to a release trigger

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,26 +1,38 @@
-name: pre-release-binaries
+name: release-binaries
 on:
-    push:
-      tags:
-        - "v*.*.*"
+  release:
+    types:
+    - released
+    - prereleased
 permissions:
   contents: write
+  id-token: write
+env:
+  GO_CACHE_INFO_FILE: wf-go-cache-info.txt
 jobs:
   publish:
     name: Build and Publish
     runs-on: ubuntu-latest
-    if: github.event_name != 'pull_request'
     strategy:
+      fail-fast: false
       matrix:
         goos: [linux, darwin]
         goarch: [amd64, arm64]
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+      # https://github.com/actions/setup-go/issues/358 - cache is shared across jobs by default since the dependency
+      # graph is the same, however each job results in different dependencies being downloaded and the first one
+      # to finish wins with regards to saving the cache.  To workaround, we create a file to include more stuff
+      - name: Create go cache info file
+        run: echo "go-cache-${{ github.workflow }}-${{ github.job }}-${{ runner.os }}-${{ matrix.goos }}-${{ matrix.goarch }}" > ${GO_CACHE_INFO_FILE}
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
+          cache-dependency-path: |
+            ${{ env.GO_CACHE_INFO_FILE }}
+            go.sum
       - name: Build
         run: |
           mkdir -p dist
@@ -29,6 +41,5 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          gh release list --limit 1 | grep -q ${{ github.ref_name }} || gh release create ${{ github.ref_name }} -d
           gh release upload ${{ github.ref_name }} dist/cofidectl-${{ matrix.goos }}-${{ matrix.goarch }}-${{ github.ref_name }} --clobber
           gh release upload ${{ github.ref_name }} LICENSE --clobber


### PR DESCRIPTION
This avoids the race to create a release. This change also brings in
some caching improvements from elsewhere.
