### PR TITLE
feat: add ListAPBindings method to DataSource interface and gRPC plugin

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ toolchain go1.24.1
 require (
 	buf.build/go/protoyaml v0.3.1
 	cuelang.org/go v0.10.1
-	github.com/cofide/cofide-api-sdk v0.14.0
+	github.com/cofide/cofide-api-sdk v0.15.0
 	github.com/fatih/color v1.18.0
 	github.com/gofrs/flock v0.12.1
 	github.com/google/go-cmp v0.7.0

--- a/go.sum
+++ b/go.sum
@@ -86,8 +86,8 @@ github.com/cncf/xds/go v0.0.0-20211001041855-01bcc9b48dfe/go.mod h1:eXthEFrGJvWH
 github.com/cncf/xds/go v0.0.0-20211011173535-cb28da3451f1/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
 github.com/cockroachdb/apd/v3 v3.2.1 h1:U+8j7t0axsIgvQUqthuNm82HIrYXodOV2iWLWtEaIwg=
 github.com/cockroachdb/apd/v3 v3.2.1/go.mod h1:klXJcjp+FffLTHlhIG69tezTDvdP065naDsHzKhYSqc=
-github.com/cofide/cofide-api-sdk v0.14.0 h1:2I91maidaRhlvFk9V9GXXQMmXMuA5Tyv1PJ0ku01z5o=
-github.com/cofide/cofide-api-sdk v0.14.0/go.mod h1:wVpHxmCOh8du8HyqhiC6iB7le9ogmXyCcnRUurpSGRU=
+github.com/cofide/cofide-api-sdk v0.15.0 h1:OMtOsLB4zsZUXcj1tbK8w1KJaTbdTF1a/MiFHN37qeg=
+github.com/cofide/cofide-api-sdk v0.15.0/go.mod h1:R4RzvFjkoHrpOfLwni4GuzFDZcyelHCdFAZMg5CNBjM=
 github.com/containerd/cgroups v1.1.0 h1:v8rEWFl6EoqHB+swVNjVoCJE8o3jX7e8nqBGPLaDFBM=
 github.com/containerd/cgroups v1.1.0/go.mod h1:6ppBcbh/NOOUU+dMKrykgaBnK9lCIBxHqJDGwsa1mIw=
 github.com/containerd/containerd v1.7.24 h1:zxszGrGjrra1yYJW/6rhm9cJ1ZQ8rkKBR48brqsa7nA=

--- a/pkg/plugin/datasource/interface.go
+++ b/pkg/plugin/datasource/interface.go
@@ -7,6 +7,7 @@ import (
 	ap_binding_proto "github.com/cofide/cofide-api-sdk/gen/go/proto/ap_binding/v1alpha1"
 	attestation_policy_proto "github.com/cofide/cofide-api-sdk/gen/go/proto/attestation_policy/v1alpha1"
 	clusterpb "github.com/cofide/cofide-api-sdk/gen/go/proto/cluster/v1alpha1"
+	datasourcepb "github.com/cofide/cofide-api-sdk/gen/go/proto/cofidectl_plugin/v1alpha1"
 	federation_proto "github.com/cofide/cofide-api-sdk/gen/go/proto/federation/v1alpha1"
 	trust_zone_proto "github.com/cofide/cofide-api-sdk/gen/go/proto/trust_zone/v1alpha1"
 	"github.com/cofide/cofidectl/pkg/plugin/validator"
@@ -32,6 +33,7 @@ type DataSource interface {
 
 	AddAPBinding(*ap_binding_proto.APBinding) (*ap_binding_proto.APBinding, error)
 	DestroyAPBinding(*ap_binding_proto.APBinding) error
+	ListAPBindings(*datasourcepb.ListAPBindingsRequest_Filter) ([]*ap_binding_proto.APBinding, error)
 
 	AddFederation(*federation_proto.Federation) (*federation_proto.Federation, error)
 	ListFederations() ([]*federation_proto.Federation, error)

--- a/pkg/plugin/datasource/plugin.go
+++ b/pkg/plugin/datasource/plugin.go
@@ -169,6 +169,15 @@ func (c *DataSourcePluginClientGRPC) DestroyAPBinding(binding *ap_binding_proto.
 	return err
 }
 
+func (c *DataSourcePluginClientGRPC) ListAPBindings(filter *cofidectl_proto.ListAPBindingsRequest_Filter) ([]*ap_binding_proto.APBinding, error) {
+	resp, err := c.client.ListAPBindings(c.ctx, &cofidectl_proto.ListAPBindingsRequest{Filter: filter})
+	if err != nil {
+		return nil, err
+	}
+
+	return resp.Bindings, nil
+}
+
 func (c *DataSourcePluginClientGRPC) AddFederation(federation *federation_proto.Federation) (*federation_proto.Federation, error) {
 	resp, err := c.client.AddFederation(c.ctx, &cofidectl_proto.AddFederationRequest{Federation: federation})
 	if err != nil {
@@ -311,6 +320,14 @@ func (s *GRPCServer) DestroyAPBinding(_ context.Context, req *cofidectl_proto.De
 		return nil, err
 	}
 	return &cofidectl_proto.DestroyAPBindingResponse{}, nil
+}
+
+func (s *GRPCServer) ListAPBindings(_ context.Context, req *cofidectl_proto.ListAPBindingsRequest) (*cofidectl_proto.ListAPBindingsResponse, error) {
+	bindings, err := s.Impl.ListAPBindings(req.Filter)
+	if err != nil {
+		return nil, err
+	}
+	return &cofidectl_proto.ListAPBindingsResponse{Bindings: bindings}, nil
 }
 
 func (s *GRPCServer) AddFederation(_ context.Context, req *cofidectl_proto.AddFederationRequest) (*cofidectl_proto.AddFederationResponse, error) {

--- a/pkg/plugin/datasource/plugin.go
+++ b/pkg/plugin/datasource/plugin.go
@@ -197,6 +197,7 @@ func (c *DataSourcePluginClientGRPC) ListFederationsByTrustZone(string) ([]*fede
 }
 
 type GRPCServer struct {
+	cofidectl_proto.UnimplementedDataSourcePluginServiceServer
 	Impl DataSource
 }
 


### PR DESCRIPTION
This is a first step towards #174, required for building with cofide-api-sdk v0.15.0, but does not use the new method.