### PR TITLE
fix: stop accessing bindings & federations in trust zone message

### DIFF
--- a/pkg/plugin/datasource/plugin.go
+++ b/pkg/plugin/datasource/plugin.go
@@ -196,8 +196,8 @@ func (c *DataSourcePluginClientGRPC) ListFederations() ([]*federation_proto.Fede
 	return resp.Federations, nil
 }
 
-func (c *DataSourcePluginClientGRPC) ListFederationsByTrustZone(string) ([]*federation_proto.Federation, error) {
-	resp, err := c.client.ListFederationsByTrustZone(c.ctx, &cofidectl_proto.ListFederationsByTrustZoneRequest{})
+func (c *DataSourcePluginClientGRPC) ListFederationsByTrustZone(trustZoneName string) ([]*federation_proto.Federation, error) {
+	resp, err := c.client.ListFederationsByTrustZone(c.ctx, &cofidectl_proto.ListFederationsByTrustZoneRequest{TrustZoneName: &trustZoneName})
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/provider/helm/values.go
+++ b/pkg/provider/helm/values.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 
 	clusterpb "github.com/cofide/cofide-api-sdk/gen/go/proto/cluster/v1alpha1"
+	datasourcepb "github.com/cofide/cofide-api-sdk/gen/go/proto/cofidectl_plugin/v1alpha1"
 	trust_zone_proto "github.com/cofide/cofide-api-sdk/gen/go/proto/trust_zone/v1alpha1"
 	"github.com/cofide/cofidectl/internal/pkg/attestationpolicy"
 	"github.com/cofide/cofidectl/internal/pkg/federation"
@@ -157,8 +158,14 @@ func (g *HelmValuesGenerator) GenerateValues() (map[string]any, error) {
 		"enabled": false,
 	}
 
+	filter := &datasourcepb.ListAPBindingsRequest_Filter{TrustZoneName: &g.trustZone.Name}
+	bindings, err := g.source.ListAPBindings(filter)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list attestation policy bindings: %w", err)
+	}
+
 	// Adds the attestation policies as ClusterSPIFFEID CRs to be reconciled by the spire-controller-manager.
-	for _, binding := range g.trustZone.AttestationPolicies {
+	for _, binding := range bindings {
 		// nolint:staticcheck
 		policy, err := g.source.GetAttestationPolicy(binding.Policy)
 		if err != nil {
@@ -173,9 +180,13 @@ func (g *HelmValuesGenerator) GenerateValues() (map[string]any, error) {
 		csids[policy.Name] = clusterSPIFFEIDs
 	}
 
+	federations, err := g.source.ListFederationsByTrustZone(g.trustZone.Name)
+	if err != nil {
+		return nil, err
+	}
 	// Adds the federations as ClusterFederatedTrustDomain CRs to be reconciled by the spire-controller-manager.
-	if len(g.trustZone.Federations) > 0 {
-		for _, fed := range g.trustZone.Federations {
+	if len(federations) > 0 {
+		for _, fed := range federations {
 			// nolint:staticcheck
 			tz, err := g.source.GetTrustZone(fed.To)
 			if err != nil {


### PR DESCRIPTION
- **fix: stop accessing bindings & federations in trust zone message**
    This change stops accessing the AttestationPolicy and Federations fields
    in the TrustZone message outside of the local datasource, instead using
    the datasource methods available to access bindings and federations.
    This allows datasource implementations to store these resources outside
    of the trust zone.
    
    Fixes: #174
- **fix: pass trust zone name to ListFederationsByTrustZone gRPC request**
