### PR TITLE
fix: bump go to 1.24.2 to fix GO-2025-3563

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/cofide/cofidectl
 
-go 1.24.0
+go 1.24.2
 
 require (
 	buf.build/go/protoyaml v0.3.2


### PR DESCRIPTION
Request smuggling due to acceptance of invalid chunked data in net/http
https://pkg.go.dev/vuln/GO-2025-3563
