### PR TITLE
feat: add CLI commands and data source methods for deletion

### DIFF
--- a/cmd/cofidectl/cmd/apbinding/apbinding.go
+++ b/cmd/cofidectl/cmd/apbinding/apbinding.go
@@ -32,8 +32,8 @@ This command consists of multiple sub-commands to administer Cofide attestation 
 
 func (c *APBindingCommand) GetRootCommand() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "attestation-policy-binding add|list [ARGS]",
-		Short: "Add or list attestation policy bindings",
+		Use:   "attestation-policy-binding add|del|list [ARGS]",
+		Short: "Manage attestation policy bindings",
 		Long:  apBindingRootCmdDesc,
 		Args:  cobra.NoArgs,
 	}

--- a/cmd/cofidectl/cmd/federation/federation.go
+++ b/cmd/cofidectl/cmd/federation/federation.go
@@ -6,9 +6,9 @@ package federation
 import (
 	"context"
 	"errors"
+	"fmt"
 	"os"
 
-	clusterpb "github.com/cofide/cofide-api-sdk/gen/go/proto/cluster/v1alpha1"
 	federation_proto "github.com/cofide/cofide-api-sdk/gen/go/proto/federation/v1alpha1"
 	trust_zone_proto "github.com/cofide/cofide-api-sdk/gen/go/proto/trust_zone/v1alpha1"
 	"github.com/cofide/cofidectl/internal/pkg/trustzone"
@@ -46,14 +46,17 @@ This command consists of multiple sub-commands to administer Cofide trust zone f
 
 func (c *FederationCommand) GetRootCommand() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "federation add|list [ARGS]",
-		Short: "Add, list federations",
+		Use:   "federation add|del|list [ARGS]",
+		Short: "Manage federations",
 		Long:  federationRootCmdDesc,
 		Args:  cobra.NoArgs,
 	}
 
-	cmd.AddCommand(c.GetListCommand())
-	cmd.AddCommand(c.GetAddCommand())
+	cmd.AddCommand(
+		c.GetListCommand(),
+		c.GetAddCommand(),
+		c.getDelCommand(),
+	)
 
 	return cmd
 }
@@ -144,7 +147,7 @@ func checkFederationStatus(ctx context.Context, ds datasource.DataSource, kubeCo
 			return "", "", err
 		}
 
-		if deployed, err := isClusterDeployed(ctx, cluster); err != nil {
+		if deployed, err := helm.IsClusterDeployed(ctx, cluster); err != nil {
 			return "", "", err
 		} else if !deployed {
 			return "Inactive", "", nil
@@ -180,22 +183,13 @@ func checkFederationStatus(ctx context.Context, ds datasource.DataSource, kubeCo
 	return FederationStatusHealthy, "", nil
 }
 
-// isClusterDeployed returns whether a cluster has been deployed, i.e. whether a SPIRE Helm release has been installed.
-func isClusterDeployed(ctx context.Context, cluster *clusterpb.Cluster) (bool, error) {
-	prov, err := helm.NewHelmSPIREProvider(ctx, cluster, nil, nil)
-	if err != nil {
-		return false, err
-	}
-	return prov.CheckIfAlreadyInstalled()
-}
-
 var federationAddCmdDesc = `
 This command will add a new federation to the Cofide configuration state.
 `
 
 type Opts struct {
-	from string
-	to   string
+	trustZone       string
+	remoteTrustZone string
 }
 
 func (c *FederationCommand) GetAddCommand() *cobra.Command {
@@ -206,14 +200,22 @@ func (c *FederationCommand) GetAddCommand() *cobra.Command {
 		Long:  federationAddCmdDesc,
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			// TODO: Remove these checks when from/to have been deprecated.
+			if opts.trustZone == "" {
+				return fmt.Errorf(`Error: required flag(s) "trust-zone" not set`)
+			}
+			if opts.remoteTrustZone == "" {
+				return fmt.Errorf(`Error: required flag(s) "remote-trust-zone" not set`)
+			}
+
 			ds, err := c.cmdCtx.PluginManager.GetDataSource(cmd.Context())
 			if err != nil {
 				return err
 			}
 
 			newFederation := &federation_proto.Federation{
-				From: opts.from,
-				To:   opts.to,
+				From: opts.trustZone,
+				To:   opts.remoteTrustZone,
 			}
 			_, err = ds.AddFederation(newFederation)
 			return err
@@ -221,11 +223,58 @@ func (c *FederationCommand) GetAddCommand() *cobra.Command {
 	}
 
 	f := cmd.Flags()
-	f.StringVar(&opts.from, "from", "", "Trust zone to federate from")
-	f.StringVar(&opts.to, "to", "", "Trust zone to federate to")
+	f.StringVar(&opts.trustZone, "trust-zone", "", "Local trust zone")
+	f.StringVar(&opts.remoteTrustZone, "remote-trust-zone", "", "Remote trust zone to federate with")
 
-	cobra.CheckErr(cmd.MarkFlagRequired("from"))
-	cobra.CheckErr(cmd.MarkFlagRequired("to"))
+	// TODO: Remove the following arguments after a suitable period.
+	f.StringVar(&opts.trustZone, "from", "", "Local trust zone")
+	f.StringVar(&opts.remoteTrustZone, "to", "", "Remote trust zone to federate with")
+
+	// TODO: Uncomment this when from/to have been deprecated.
+	// cobra.CheckErr(cmd.MarkFlagRequired("trust-zone"))
+	// cobra.CheckErr(cmd.MarkFlagRequired("remote-trust-zone"))
+
+	cmd.MarkFlagsMutuallyExclusive("from", "trust-zone")
+	cmd.MarkFlagsMutuallyExclusive("to", "remote-trust-zone")
 
 	return cmd
+}
+
+var federationDelCmdDesc = `
+This command will delete a federation from the Cofide configuration state.
+`
+
+func (c *FederationCommand) getDelCommand() *cobra.Command {
+	opts := Opts{}
+	cmd := &cobra.Command{
+		Use:   "del",
+		Short: "Delete a federation",
+		Long:  federationDelCmdDesc,
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return c.deleteFederation(cmd.Context(), opts.trustZone, opts.remoteTrustZone)
+		},
+	}
+
+	f := cmd.Flags()
+	f.StringVar(&opts.trustZone, "trust-zone", "", "Local trust zone")
+	f.StringVar(&opts.remoteTrustZone, "remote-trust-zone", "", "Remote trust zone to federate with")
+
+	cobra.CheckErr(cmd.MarkFlagRequired("trust-zone"))
+	cobra.CheckErr(cmd.MarkFlagRequired("remote-trust-zone"))
+
+	return cmd
+}
+
+func (c *FederationCommand) deleteFederation(ctx context.Context, trustZone, remoteTrustZone string) error {
+	ds, err := c.cmdCtx.PluginManager.GetDataSource(ctx)
+	if err != nil {
+		return err
+	}
+
+	federation := &federation_proto.Federation{
+		From: trustZone,
+		To:   remoteTrustZone,
+	}
+	return ds.DestroyFederation(federation)
 }

--- a/cmd/cofidectl/cmd/trustzone/trustzone_test.go
+++ b/cmd/cofidectl/cmd/trustzone/trustzone_test.go
@@ -4,9 +4,19 @@
 package trustzone
 
 import (
+	"context"
+	"errors"
 	"testing"
 
+	clusterpb "github.com/cofide/cofide-api-sdk/gen/go/proto/cluster/v1alpha1"
+	trust_zone_proto "github.com/cofide/cofide-api-sdk/gen/go/proto/trust_zone/v1alpha1"
+	"github.com/cofide/cofide-api-sdk/pkg/connect/client/test"
+	"github.com/cofide/cofidectl/internal/pkg/config"
+	"github.com/cofide/cofidectl/internal/pkg/test/fixtures"
+	"github.com/cofide/cofidectl/pkg/plugin/datasource"
+	"github.com/cofide/cofidectl/pkg/plugin/local"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestValidateOpts(t *testing.T) {
@@ -32,5 +42,184 @@ func TestValidateOpts(t *testing.T) {
 			err := validateOpts(addOpts{trustDomain: tc.domain})
 			assert.Equal(t, tc.errExpected, err != nil)
 		})
+	}
+}
+
+func TestTrustZoneCommand_addTrustZone(t *testing.T) {
+	tests := []struct {
+		name           string
+		trustZoneName  string
+		injectFailure  bool
+		wantErr        bool
+		wantErrMessage string
+	}{
+		{
+			name:          "success",
+			trustZoneName: "tz3",
+		},
+		{
+			name:           "already exists",
+			trustZoneName:  "tz1",
+			wantErr:        true,
+			wantErrMessage: "trust zone tz1 already exists in local config",
+		},
+		{
+			name:           "trust zone add rollback",
+			trustZoneName:  "tz3",
+			injectFailure:  true,
+			wantErr:        true,
+			wantErrMessage: "fake destroy failure",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ds := newFakeDataSource(t, defaultConfig())
+			if tt.injectFailure {
+				ds = &failingDS{LocalDataSource: ds.(*local.LocalDataSource)}
+			}
+			opts := addOpts{
+				name:              tt.trustZoneName,
+				trustDomain:       "td3",
+				kubernetesCluster: "local3",
+				context:           "kind-local3",
+				profile:           "kubernetes",
+				noCluster:         false,
+			}
+			c := TrustZoneCommand{}
+			err := c.addTrustZone(context.Background(), opts, ds)
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.ErrorContains(t, err, tt.wantErrMessage)
+
+				// Check that trust zone and cluster were not added.
+				_, err := ds.GetTrustZone("tz3")
+				require.Error(t, err)
+				_, err = ds.GetCluster("local3", "tz3")
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+
+				// Check that trust zone and cluster were added.
+				_, err := ds.GetTrustZone(tt.trustZoneName)
+				require.NoError(t, err)
+				_, err = ds.GetCluster("local3", tt.trustZoneName)
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestTrustZoneCommand_deleteTrustZone(t *testing.T) {
+	tests := []struct {
+		name           string
+		trustZoneName  string
+		injectFailure  bool
+		wantErr        bool
+		wantErrMessage string
+	}{
+		{
+			name:          "exists",
+			trustZoneName: "tz1",
+		},
+		{
+			name:           "doesn't exist",
+			trustZoneName:  "invalid tz",
+			wantErr:        true,
+			wantErrMessage: "failed to find trust zone invalid tz in local config",
+		},
+		{
+			name:           "cluster delete rollback",
+			trustZoneName:  "tz1",
+			injectFailure:  true,
+			wantErr:        true,
+			wantErrMessage: "fake destroy failure",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ds := newFakeDataSource(t, defaultConfig())
+			if tt.injectFailure {
+				ds = &failingDS{LocalDataSource: ds.(*local.LocalDataSource)}
+			}
+			err := deleteTrustZone(context.Background(), tt.trustZoneName, ds, false)
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.ErrorContains(t, err, tt.wantErrMessage)
+
+				// Check that trust zone and clusters were not deleted.
+				_, err := ds.GetTrustZone("tz1")
+				require.NoError(t, err)
+				if tt.injectFailure {
+					// Currently the local datasource limits us to one cluster per trust zone, so rolling back deletion fails.
+					assert.Equal(t, 1, ds.(*failingDS).clustersAdded)
+				} else {
+					for _, cluster := range defaultConfig().Clusters {
+						_, err := ds.GetCluster(cluster.GetName(), cluster.GetTrustZone())
+						require.NoError(t, err)
+					}
+				}
+			} else {
+				require.NoError(t, err)
+
+				// Check that trust zone and clusters were deleted.
+				_, err := ds.GetTrustZone(tt.trustZoneName)
+				require.Error(t, err)
+				for _, cluster := range defaultConfig().Clusters {
+					_, err := ds.GetCluster(cluster.GetName(), cluster.GetTrustZone())
+					require.Error(t, err)
+				}
+			}
+		})
+	}
+}
+
+type failingDS struct {
+	*local.LocalDataSource
+	clustersDestroyed int
+	clustersAdded     int
+}
+
+// AddTrustZone fails unconditionally.
+func (f *failingDS) AddTrustZone(trustZone *trust_zone_proto.TrustZone) (*trust_zone_proto.TrustZone, error) {
+	return nil, errors.New("fake destroy failure")
+}
+
+// AddCluster keeps track of the number of clusters added.
+func (f *failingDS) AddCluster(cluster *clusterpb.Cluster) (*clusterpb.Cluster, error) {
+	f.clustersAdded++
+	return f.LocalDataSource.AddCluster(cluster)
+}
+
+// DestroyCluster fails when a second cluster is destroyed, allowing testing of rollback.
+func (f *failingDS) DestroyCluster(name, trustZoneName string) error {
+	f.clustersDestroyed++
+	if f.clustersDestroyed == 2 {
+		return errors.New("fake destroy failure")
+	}
+	return f.LocalDataSource.DestroyCluster(name, trustZoneName)
+}
+
+func newFakeDataSource(t *testing.T, cfg *config.Config) datasource.DataSource {
+	configLoader, err := config.NewMemoryLoader(cfg)
+	require.Nil(t, err)
+	lds, err := local.NewLocalDataSource(configLoader)
+	require.Nil(t, err)
+	return lds
+}
+
+func defaultConfig() *config.Config {
+	return &config.Config{
+		TrustZones: []*trust_zone_proto.TrustZone{
+			fixtures.TrustZone("tz1"),
+		},
+		Clusters: []*clusterpb.Cluster{
+			fixtures.Cluster("local1"),
+			func() *clusterpb.Cluster {
+				cluster := fixtures.Cluster("local1")
+				cluster.Name = test.PtrOf("local2")
+				return cluster
+			}(),
+		},
+		Plugins: fixtures.Plugins("plugins1"),
 	}
 }

--- a/cmd/cofidectl/cmd/workload/workload.go
+++ b/cmd/cofidectl/cmd/workload/workload.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 	"os"
 
-	clusterpb "github.com/cofide/cofide-api-sdk/gen/go/proto/cluster/v1alpha1"
 	provisionpb "github.com/cofide/cofide-api-sdk/gen/go/proto/provision_plugin/v1alpha1"
 	trust_zone_proto "github.com/cofide/cofide-api-sdk/gen/go/proto/trust_zone/v1alpha1"
 	"github.com/cofide/cofidectl/cmd/cofidectl/cmd/statusspinner"
@@ -204,7 +203,7 @@ func renderRegisteredWorkloads(ctx context.Context, ds datasource.DataSource, ku
 			return err
 		}
 
-		if deployed, err := isClusterDeployed(ctx, cluster); err != nil {
+		if deployed, err := helm.IsClusterDeployed(ctx, cluster); err != nil {
 			return err
 		} else if !deployed {
 			return fmt.Errorf("trust zone %s has not been deployed", trustZone.Name)
@@ -325,7 +324,7 @@ func renderUnregisteredWorkloads(ctx context.Context, ds datasource.DataSource, 
 			return err
 		}
 
-		deployed, err := isClusterDeployed(ctx, cluster)
+		deployed, err := helm.IsClusterDeployed(ctx, cluster)
 		if err != nil {
 			return err
 		}
@@ -361,13 +360,4 @@ func renderUnregisteredWorkloads(ctx context.Context, ds datasource.DataSource, 
 	table.Render()
 
 	return nil
-}
-
-// isClusterDeployed returns whether a cluster has been deployed, i.e. whether a SPIRE Helm release has been installed.
-func isClusterDeployed(ctx context.Context, cluster *clusterpb.Cluster) (bool, error) {
-	prov, err := helm.NewHelmSPIREProvider(ctx, cluster, nil, nil)
-	if err != nil {
-		return false, err
-	}
-	return prov.CheckIfAlreadyInstalled()
 }

--- a/pkg/plugin/datasource/interface.go
+++ b/pkg/plugin/datasource/interface.go
@@ -18,16 +18,19 @@ type DataSource interface {
 	validator.Validator
 
 	AddTrustZone(*trust_zone_proto.TrustZone) (*trust_zone_proto.TrustZone, error)
+	DestroyTrustZone(string) error
 	GetTrustZone(string) (*trust_zone_proto.TrustZone, error)
 	ListTrustZones() ([]*trust_zone_proto.TrustZone, error)
 	UpdateTrustZone(*trust_zone_proto.TrustZone) (*trust_zone_proto.TrustZone, error)
 
 	AddCluster(*clusterpb.Cluster) (*clusterpb.Cluster, error)
+	DestroyCluster(string, string) error
 	GetCluster(string, string) (*clusterpb.Cluster, error)
 	ListClusters(string) ([]*clusterpb.Cluster, error)
 	UpdateCluster(*clusterpb.Cluster) (*clusterpb.Cluster, error)
 
 	AddAttestationPolicy(*attestation_policy_proto.AttestationPolicy) (*attestation_policy_proto.AttestationPolicy, error)
+	DestroyAttestationPolicy(string) error
 	GetAttestationPolicy(string) (*attestation_policy_proto.AttestationPolicy, error)
 	ListAttestationPolicies() ([]*attestation_policy_proto.AttestationPolicy, error)
 
@@ -36,6 +39,7 @@ type DataSource interface {
 	ListAPBindings(*datasourcepb.ListAPBindingsRequest_Filter) ([]*ap_binding_proto.APBinding, error)
 
 	AddFederation(*federation_proto.Federation) (*federation_proto.Federation, error)
+	DestroyFederation(*federation_proto.Federation) error
 	ListFederations() ([]*federation_proto.Federation, error)
 	ListFederationsByTrustZone(string) ([]*federation_proto.Federation, error)
 }

--- a/pkg/plugin/datasource/plugin.go
+++ b/pkg/plugin/datasource/plugin.go
@@ -65,6 +65,11 @@ func (c *DataSourcePluginClientGRPC) AddTrustZone(trustZone *trust_zone_proto.Tr
 	return resp.TrustZone, nil
 }
 
+func (c *DataSourcePluginClientGRPC) DestroyTrustZone(name string) error {
+	_, err := c.client.DestroyTrustZone(c.ctx, &cofidectl_proto.DestroyTrustZoneRequest{Name: &name})
+	return err
+}
+
 func (c *DataSourcePluginClientGRPC) GetTrustZone(name string) (*trust_zone_proto.TrustZone, error) {
 	resp, err := c.client.GetTrustZone(c.ctx, &cofidectl_proto.GetTrustZoneRequest{Name: &name})
 	if err != nil {
@@ -101,6 +106,11 @@ func (c *DataSourcePluginClientGRPC) AddCluster(cluster *clusterpb.Cluster) (*cl
 	return resp.Cluster, nil
 }
 
+func (c *DataSourcePluginClientGRPC) DestroyCluster(name, trustZoneName string) error {
+	_, err := c.client.DestroyCluster(c.ctx, &cofidectl_proto.DestroyClusterRequest{Name: &name, TrustZone: &trustZoneName})
+	return err
+}
+
 func (c *DataSourcePluginClientGRPC) GetCluster(name, trustZone string) (*clusterpb.Cluster, error) {
 	resp, err := c.client.GetCluster(c.ctx, &cofidectl_proto.GetClusterRequest{Name: &name, TrustZone: &trustZone})
 	if err != nil {
@@ -135,6 +145,11 @@ func (c *DataSourcePluginClientGRPC) AddAttestationPolicy(policy *attestation_po
 	}
 
 	return resp.Policy, nil
+}
+
+func (c *DataSourcePluginClientGRPC) DestroyAttestationPolicy(name string) error {
+	_, err := c.client.DestroyAttestationPolicy(c.ctx, &cofidectl_proto.DestroyAttestationPolicyRequest{Name: &name})
+	return err
 }
 
 func (c *DataSourcePluginClientGRPC) GetAttestationPolicy(name string) (*attestation_policy_proto.AttestationPolicy, error) {
@@ -187,6 +202,11 @@ func (c *DataSourcePluginClientGRPC) AddFederation(federation *federation_proto.
 	return resp.Federation, nil
 }
 
+func (c *DataSourcePluginClientGRPC) DestroyFederation(federation *federation_proto.Federation) error {
+	_, err := c.client.DestroyFederation(c.ctx, &cofidectl_proto.DestroyFederationRequest{Federation: federation})
+	return err
+}
+
 func (c *DataSourcePluginClientGRPC) ListFederations() ([]*federation_proto.Federation, error) {
 	resp, err := c.client.ListFederations(c.ctx, &cofidectl_proto.ListFederationsRequest{})
 	if err != nil {
@@ -226,6 +246,14 @@ func (s *GRPCServer) AddTrustZone(_ context.Context, req *cofidectl_proto.AddTru
 	return &cofidectl_proto.AddTrustZoneResponse{TrustZone: trustZone}, nil
 }
 
+func (s *GRPCServer) DestroyTrustZone(_ context.Context, req *cofidectl_proto.DestroyTrustZoneRequest) (*cofidectl_proto.DestroyTrustZoneResponse, error) {
+	err := s.Impl.DestroyTrustZone(req.GetName())
+	if err != nil {
+		return nil, err
+	}
+	return &cofidectl_proto.DestroyTrustZoneResponse{}, nil
+}
+
 func (s *GRPCServer) GetTrustZone(_ context.Context, req *cofidectl_proto.GetTrustZoneRequest) (*cofidectl_proto.GetTrustZoneResponse, error) {
 	trustZone, err := s.Impl.GetTrustZone(req.GetName())
 	if err != nil {
@@ -258,6 +286,14 @@ func (s *GRPCServer) AddCluster(_ context.Context, req *cofidectl_proto.AddClust
 	return &cofidectl_proto.AddClusterResponse{Cluster: cluster}, nil
 }
 
+func (s *GRPCServer) DestroyCluster(_ context.Context, req *cofidectl_proto.DestroyClusterRequest) (*cofidectl_proto.DestroyClusterResponse, error) {
+	err := s.Impl.DestroyCluster(req.GetName(), req.GetTrustZone())
+	if err != nil {
+		return nil, err
+	}
+	return &cofidectl_proto.DestroyClusterResponse{}, nil
+}
+
 func (s *GRPCServer) GetCluster(_ context.Context, req *cofidectl_proto.GetClusterRequest) (*cofidectl_proto.GetClusterResponse, error) {
 	cluster, err := s.Impl.GetCluster(req.GetName(), req.GetTrustZone())
 	if err != nil {
@@ -288,6 +324,14 @@ func (s *GRPCServer) AddAttestationPolicy(_ context.Context, req *cofidectl_prot
 		return nil, err
 	}
 	return &cofidectl_proto.AddAttestationPolicyResponse{Policy: policy}, nil
+}
+
+func (s *GRPCServer) DestroyAttestationPolicy(_ context.Context, req *cofidectl_proto.DestroyAttestationPolicyRequest) (*cofidectl_proto.DestroyAttestationPolicyResponse, error) {
+	err := s.Impl.DestroyAttestationPolicy(req.GetName())
+	if err != nil {
+		return nil, err
+	}
+	return &cofidectl_proto.DestroyAttestationPolicyResponse{}, nil
 }
 
 func (s *GRPCServer) GetAttestationPolicy(_ context.Context, req *cofidectl_proto.GetAttestationPolicyRequest) (*cofidectl_proto.GetAttestationPolicyResponse, error) {
@@ -336,6 +380,14 @@ func (s *GRPCServer) AddFederation(_ context.Context, req *cofidectl_proto.AddFe
 		return nil, err
 	}
 	return &cofidectl_proto.AddFederationResponse{Federation: federation}, nil
+}
+
+func (s *GRPCServer) DestroyFederation(_ context.Context, req *cofidectl_proto.DestroyFederationRequest) (*cofidectl_proto.DestroyFederationResponse, error) {
+	err := s.Impl.DestroyFederation(req.GetFederation())
+	if err != nil {
+		return nil, err
+	}
+	return &cofidectl_proto.DestroyFederationResponse{}, nil
 }
 
 func (s *GRPCServer) ListFederations(_ context.Context, req *cofidectl_proto.ListFederationsRequest) (*cofidectl_proto.ListFederationsResponse, error) {

--- a/pkg/provider/helm/helm.go
+++ b/pkg/provider/helm/helm.go
@@ -408,3 +408,12 @@ func checkIfAlreadyInstalled(cfg *action.Configuration, chartName string) (bool,
 	}
 	return len(ledger) > 0, nil
 }
+
+// IsClusterDeployed returns whether a cluster has been deployed, i.e. whether a SPIRE Helm release has been installed.
+func IsClusterDeployed(ctx context.Context, cluster *clusterpb.Cluster) (bool, error) {
+	prov, err := NewHelmSPIREProvider(ctx, cluster, nil, nil)
+	if err != nil {
+		return false, err
+	}
+	return prov.CheckIfAlreadyInstalled()
+}

--- a/tests/integration/federation/test.sh
+++ b/tests/integration/federation/test.sh
@@ -54,7 +54,7 @@ function configure() {
   ./cofidectl trust-zone add $TRUST_ZONE_1 --trust-domain $TRUST_DOMAIN_1 --kubernetes-context $K8S_CLUSTER_1_CONTEXT --kubernetes-cluster $K8S_CLUSTER_1_NAME --profile kubernetes
   ./cofidectl trust-zone add $TRUST_ZONE_2 --trust-domain $TRUST_DOMAIN_2 --kubernetes-context $K8S_CLUSTER_2_CONTEXT --kubernetes-cluster $K8S_CLUSTER_2_NAME --profile kubernetes
   ./cofidectl federation add --from $TRUST_ZONE_1 --to $TRUST_ZONE_2
-  ./cofidectl federation add --from $TRUST_ZONE_2 --to $TRUST_ZONE_1
+  ./cofidectl federation add --trust-zone $TRUST_ZONE_2 --remote-trust-zone $TRUST_ZONE_1
   ./cofidectl attestation-policy add kubernetes --name namespace --namespace $NAMESPACE_POLICY_NAMESPACE
   ./cofidectl attestation-policy add kubernetes --name pod-label --pod-label $POD_POLICY_POD_LABEL
   ./cofidectl attestation-policy-binding add --trust-zone $TRUST_ZONE_1 --attestation-policy namespace --federates-with $TRUST_ZONE_2
@@ -154,6 +154,20 @@ function down() {
   ./cofidectl down --trust-zone $TRUST_ZONE_1 --trust-zone $TRUST_ZONE_2
 }
 
+function delete() {
+  ./cofidectl attestation-policy-binding del --trust-zone $TRUST_ZONE_1 --attestation-policy namespace
+  ./cofidectl attestation-policy-binding del --trust-zone $TRUST_ZONE_1 --attestation-policy pod-label
+  # Don't delete attestation policy bindings for trust zone 2 - check that they get deleted with the trust zone.
+  ./cofidectl cluster del $K8S_CLUSTER_1_NAME --trust-zone $TRUST_ZONE_1
+  ./cofidectl cluster del $K8S_CLUSTER_2_NAME --trust-zone $TRUST_ZONE_2
+  ./cofidectl federation del --trust-zone $TRUST_ZONE_1 --remote-trust-zone $TRUST_ZONE_2
+  # Don't delete federation for trust zone 2 - check that it gets deleted with the trust zone.
+  ./cofidectl trust-zone del $TRUST_ZONE_1
+  ./cofidectl trust-zone del $TRUST_ZONE_2
+  ./cofidectl attestation-policy del namespace
+  ./cofidectl attestation-policy del pod-label
+}
+
 function main() {
   init
   check_init
@@ -168,6 +182,8 @@ function main() {
   show_workload_status
   teardown_federation_and_verify
   down
+  delete
+  check_delete
   echo "Success!"
 }
 

--- a/tests/integration/lib.sh
+++ b/tests/integration/lib.sh
@@ -23,3 +23,21 @@ function check_spire_csi_driver() {
     return 1
   fi
 }
+
+function check_delete() {
+  trust_zones="$(yq '.trust_zones' cofide.yaml -r)"
+  clusters="$(yq '.clusters' cofide.yaml -r)"
+  attestation_policies="$(yq '.attestation_policies' cofide.yaml -r)"
+  if [[ "$trust_zones" != "null" ]]; then
+    echo "Unexpected trust zones in cofide.yaml: $trust_zones"
+    exit 1
+  fi
+  if [[ "$clusters" != "null" ]]; then
+    echo "Unexpected clusters in cofide.yaml: $clusters"
+    exit 1
+  fi
+  if [[ "$attestation_policies" != "null" ]]; then
+    echo "Unexpected attestation policies in cofide.yaml: $attestation_policies"
+    exit 1
+  fi
+}

--- a/tests/integration/single-trust-zone/test.sh
+++ b/tests/integration/single-trust-zone/test.sh
@@ -140,6 +140,17 @@ function down() {
   ./cofidectl down
 }
 
+function delete() {
+  ./cofidectl attestation-policy-binding del --trust-zone $TRUST_ZONE --attestation-policy namespace
+  ./cofidectl attestation-policy-binding del --trust-zone $TRUST_ZONE --attestation-policy pod-label
+  ./cofidectl attestation-policy-binding del --trust-zone $TRUST_ZONE --attestation-policy static-namespace
+  ./cofidectl attestation-policy del namespace
+  ./cofidectl attestation-policy del pod-label
+  ./cofidectl attestation-policy del static-namespace
+  ./cofidectl cluster del $K8S_CLUSTER_NAME --trust-zone $TRUST_ZONE
+  ./cofidectl trust-zone del $TRUST_ZONE
+}
+
 function main() {
   init
   configure
@@ -152,6 +163,8 @@ function main() {
   show_workload_status
   check_overridden_values
   down
+  delete
+  check_delete
   echo "Success!"
 }
 


### PR DESCRIPTION
This change adds the following CLI commands:

- attestation-policy del
- cluster del
- federation del
- trust-zone del

They delete the corresponding resource type.

It also adds DataSource interface methods:

- DestroyTrustZone
- DestroyCluster
- DestroyAttestationPolicy
- DestroyFederation

The integration tests have been updated to exercise the new commands.

It also adds support for alternative argument names in the federation
add command, as required by #49.

Fixes: #206
Fixes: #49
