### PR TITLE
Add UUIDs to local resources

### DIFF
--- a/internal/pkg/config/schema.cue
+++ b/internal/pkg/config/schema.cue
@@ -1,6 +1,7 @@
 #DataSource: string
 
 #TrustZone: {
+	id?: string
 	name!: string
 	trust_domain!: string
 	bundle_endpoint_url?: string
@@ -32,6 +33,7 @@
 }
 
 #Cluster: {
+	id?: string
 	name!: string
 	trust_zone!: string
 	kubernetes_context!: string
@@ -47,12 +49,14 @@
 }
 
 #APBinding: {
+	id?: string
 	trust_zone!: string
 	policy!: string
 	federates_with: [...string]
 }
 
 #AttestationPolicy: {
+	id?: string
 	name!: string
 	#APKubernetes | #APStatic
 }
@@ -89,6 +93,7 @@
 }
 
 #Federation: {
+	id?: string
 	from!: string
 	to!: string
 }

--- a/internal/pkg/config/validator_test.go
+++ b/internal/pkg/config/validator_test.go
@@ -94,7 +94,7 @@ func TestValidator_ValidateInvalid(t *testing.T) {
 		{
 			name:    "missing attestation policy field",
 			data:    string(readTestConfig(t, "missing_attestation_policy_field.yaml")),
-			wantErr: "attestation_policies.0: incomplete value {name:\"ap1\",kubernetes?:{namespace_selector?:{match_labels?:{},match_expressions?:[]},pod_selector?:{match_labels?:{},match_expressions?:[]}}} | {name:\"ap1\",static?:{spiffe_id!:string,selectors!:[]}}",
+			wantErr: "attestation_policies.0: incomplete value {name:\"ap1\",id?:string,kubernetes?:{namespace_selector?:{match_labels?:{},match_expressions?:[]},pod_selector?:{match_labels?:{},match_expressions?:[]}}} | {name:\"ap1\",id?:string,static?:{spiffe_id!:string,selectors!:[]}}",
 		},
 		{
 			name:    "plugins not a map",

--- a/pkg/plugin/local/local.go
+++ b/pkg/plugin/local/local.go
@@ -81,17 +81,20 @@ func (lds *LocalDataSource) updateDataFile() error {
 }
 
 func (lds *LocalDataSource) AddTrustZone(trustZone *trust_zone_proto.TrustZone) (*trust_zone_proto.TrustZone, error) {
-	if trustZone.Id == nil || *trustZone.Id == "" {
-		id, err := generateId()
-		if err != nil {
-			return nil, fmt.Errorf("failed to generate UUID for trust zone: %w", err)
-		}
-		trustZone.Id = id
+	if trustZone.GetId() != "" {
+		return nil, fmt.Errorf("trust zone %s should not have an ID set, this will be auto generated", trustZone.GetId())
 	}
+
+	id, err := generateId()
+	if err != nil {
+		return nil, fmt.Errorf("failed to generate UUID for trust zone: %w", err)
+	}
+	trustZone.Id = id
+
 	if _, ok := lds.config.GetTrustZoneByName(trustZone.Name); ok {
 		return nil, fmt.Errorf("trust zone %s already exists in local config", trustZone.Name)
 	}
-	trustZone, err := proto.CloneTrustZone(trustZone)
+	trustZone, err = proto.CloneTrustZone(trustZone)
 	if err != nil {
 		return nil, err
 	}
@@ -172,13 +175,14 @@ func (lds *LocalDataSource) AddCluster(cluster *clusterpb.Cluster) (*clusterpb.C
 	name := cluster.GetName()
 	trustZone := cluster.GetTrustZone()
 
-	if cluster.Id == nil || *cluster.Id == "" {
-		id, err := generateId()
-		if err != nil {
-			return nil, fmt.Errorf("failed to generate UUID for cluster: %w", err)
-		}
-		cluster.Id = id
+	if cluster.GetId() != "" {
+		return nil, fmt.Errorf("cluster %s should not have an ID set, this will be auto generated", cluster.GetId())
 	}
+	id, err := generateId()
+	if err != nil {
+		return nil, fmt.Errorf("failed to generate UUID for cluster: %w", err)
+	}
+	cluster.Id = id
 
 	if _, ok := lds.config.GetClusterByName(name, trustZone); ok {
 		return nil, fmt.Errorf("cluster %s already exists in trust zone %s in local config", name, trustZone)
@@ -188,7 +192,7 @@ func (lds *LocalDataSource) AddCluster(cluster *clusterpb.Cluster) (*clusterpb.C
 		return nil, fmt.Errorf("trust zone %s already has a cluster", trustZone)
 	}
 
-	cluster, err := proto.CloneCluster(cluster)
+	cluster, err = proto.CloneCluster(cluster)
 	if err != nil {
 		return nil, err
 	}
@@ -286,17 +290,20 @@ func validateTrustProviderUpdate(cluster, tzName string, current, new *trust_pro
 }
 
 func (lds *LocalDataSource) AddAttestationPolicy(policy *attestation_policy_proto.AttestationPolicy) (*attestation_policy_proto.AttestationPolicy, error) {
-	if policy.Id == nil || *policy.Id == "" {
-		id, err := generateId()
-		if err != nil {
-			return nil, fmt.Errorf("failed to generate UUID for attestation policy: %w", err)
-		}
-		policy.Id = id
+	if policy.GetId() != "" {
+		return nil, fmt.Errorf("attestation policy %s should not have an ID set, this will be auto generated", *policy.Id)
 	}
+
+	id, err := generateId()
+	if err != nil {
+		return nil, fmt.Errorf("failed to generate UUID for attestation policy: %w", err)
+	}
+	policy.Id = id
+
 	if _, ok := lds.config.GetAttestationPolicyByName(policy.Name); ok {
 		return nil, fmt.Errorf("attestation policy %s already exists in local config", policy.Name)
 	}
-	policy, err := proto.CloneAttestationPolicy(policy)
+	policy, err = proto.CloneAttestationPolicy(policy)
 	if err != nil {
 		return nil, err
 	}
@@ -328,13 +335,16 @@ func (lds *LocalDataSource) ListAttestationPolicies() ([]*attestation_policy_pro
 }
 
 func (lds *LocalDataSource) AddAPBinding(binding *ap_binding_proto.APBinding) (*ap_binding_proto.APBinding, error) {
-	if binding.Id == nil || *binding.Id == "" {
-		id, err := generateId()
-		if err != nil {
-			return nil, fmt.Errorf("failed to generate UUID for attestation policy binding: %w", err)
-		}
-		binding.Id = id
+	if binding.GetId() != "" {
+		return nil, fmt.Errorf("attestation policy binding %s should not have an ID set, this will be auto generated", *binding.Id)
 	}
+
+	id, err := generateId()
+	if err != nil {
+		return nil, fmt.Errorf("failed to generate UUID for attestation policy binding: %w", err)
+	}
+	binding.Id = id
+
 	// nolint:staticcheck
 	localTrustZone, ok := lds.config.GetTrustZoneByName(binding.TrustZone)
 	if !ok {
@@ -381,7 +391,7 @@ func (lds *LocalDataSource) AddAPBinding(binding *ap_binding_proto.APBinding) (*
 		}
 	}
 
-	binding, err := proto.CloneAPBinding(binding)
+	binding, err = proto.CloneAPBinding(binding)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/plugin/local/local.go
+++ b/pkg/plugin/local/local.go
@@ -18,7 +18,18 @@ import (
 	"github.com/cofide/cofidectl/internal/pkg/config"
 	"github.com/cofide/cofidectl/internal/pkg/proto"
 	"github.com/cofide/cofidectl/pkg/plugin/datasource"
+
+	"github.com/google/uuid"
 )
+
+func generateId() (*string, error) {
+	uid, err := uuid.NewUUID()
+	if err != nil {
+		return nil, fmt.Errorf("failed to generate UUID: %w", err)
+	}
+	id := uid.String()
+	return &id, nil
+}
 
 var _ datasource.DataSource = (*LocalDataSource)(nil)
 
@@ -70,6 +81,13 @@ func (lds *LocalDataSource) updateDataFile() error {
 }
 
 func (lds *LocalDataSource) AddTrustZone(trustZone *trust_zone_proto.TrustZone) (*trust_zone_proto.TrustZone, error) {
+	if trustZone.Id == nil || *trustZone.Id == "" {
+		id, err := generateId()
+		if err != nil {
+			return nil, fmt.Errorf("failed to generate UUID for trust zone: %w", err)
+		}
+		trustZone.Id = id
+	}
 	if _, ok := lds.config.GetTrustZoneByName(trustZone.Name); ok {
 		return nil, fmt.Errorf("trust zone %s already exists in local config", trustZone.Name)
 	}
@@ -153,6 +171,14 @@ func validateTrustZoneUpdate(current, new *trust_zone_proto.TrustZone) error {
 func (lds *LocalDataSource) AddCluster(cluster *clusterpb.Cluster) (*clusterpb.Cluster, error) {
 	name := cluster.GetName()
 	trustZone := cluster.GetTrustZone()
+
+	if cluster.Id == nil || *cluster.Id == "" {
+		id, err := generateId()
+		if err != nil {
+			return nil, fmt.Errorf("failed to generate UUID for cluster: %w", err)
+		}
+		cluster.Id = id
+	}
 
 	if _, ok := lds.config.GetClusterByName(name, trustZone); ok {
 		return nil, fmt.Errorf("cluster %s already exists in trust zone %s in local config", name, trustZone)
@@ -260,6 +286,13 @@ func validateTrustProviderUpdate(cluster, tzName string, current, new *trust_pro
 }
 
 func (lds *LocalDataSource) AddAttestationPolicy(policy *attestation_policy_proto.AttestationPolicy) (*attestation_policy_proto.AttestationPolicy, error) {
+	if policy.Id == nil || *policy.Id == "" {
+		id, err := generateId()
+		if err != nil {
+			return nil, fmt.Errorf("failed to generate UUID for attestation policy: %w", err)
+		}
+		policy.Id = id
+	}
 	if _, ok := lds.config.GetAttestationPolicyByName(policy.Name); ok {
 		return nil, fmt.Errorf("attestation policy %s already exists in local config", policy.Name)
 	}
@@ -295,6 +328,13 @@ func (lds *LocalDataSource) ListAttestationPolicies() ([]*attestation_policy_pro
 }
 
 func (lds *LocalDataSource) AddAPBinding(binding *ap_binding_proto.APBinding) (*ap_binding_proto.APBinding, error) {
+	if binding.Id == nil || *binding.Id == "" {
+		id, err := generateId()
+		if err != nil {
+			return nil, fmt.Errorf("failed to generate UUID for attestation policy binding: %w", err)
+		}
+		binding.Id = id
+	}
 	// nolint:staticcheck
 	localTrustZone, ok := lds.config.GetTrustZoneByName(binding.TrustZone)
 	if !ok {
@@ -408,6 +448,13 @@ func (lds *LocalDataSource) ListAPBindings(filter *datasourcepb.ListAPBindingsRe
 }
 
 func (lds *LocalDataSource) AddFederation(federationProto *federation_proto.Federation) (*federation_proto.Federation, error) {
+	if federationProto.Id == nil || *federationProto.Id == "" {
+		id, err := generateId()
+		if err != nil {
+			return nil, fmt.Errorf("failed to generate UUID for federation: %w", err)
+		}
+		federationProto.Id = id
+	}
 	// nolint:staticcheck
 	fromTrustZone, ok := lds.config.GetTrustZoneByName(federationProto.From)
 	if !ok {

--- a/pkg/plugin/local/local_test.go
+++ b/pkg/plugin/local/local_test.go
@@ -384,6 +384,7 @@ func TestLocalDataSource_AddCluster(t *testing.T) {
 				gotCluster, ok := gotConfig.GetClusterByName(tt.cluster.GetName(), tt.cluster.GetTrustZone())
 				assert.True(t, ok)
 				assert.EqualExportedValues(t, tt.cluster, gotCluster)
+				assert.NotNil(t, gotCluster.Id)
 			}
 		})
 	}
@@ -651,6 +652,7 @@ func TestLocalDataSource_AddAttestationPolicy(t *testing.T) {
 				gotPolicy, ok := gotConfig.GetAttestationPolicyByName(tt.policy.Name)
 				assert.True(t, ok)
 				assert.EqualExportedValues(t, tt.policy, gotPolicy)
+				assert.NotNil(t, gotPolicy.Id)
 			}
 		})
 	}
@@ -846,6 +848,7 @@ func TestLocalDataSource_AddAPBinding(t *testing.T) {
 				// nolint:staticcheck
 				gotBinding := gotConfig.TrustZones[0].AttestationPolicies[1]
 				assert.EqualExportedValues(t, tt.binding, gotBinding)
+				assert.NotNil(t, gotBinding.Id)
 			}
 		})
 	}
@@ -925,8 +928,8 @@ func TestLocalDataSource_ListAPBindings(t *testing.T) {
 		wantErrString string
 	}{
 		{
-			name:    "no filter",
-			filter:  &datasourcepb.ListAPBindingsRequest_Filter{},
+			name:   "no filter",
+			filter: &datasourcepb.ListAPBindingsRequest_Filter{},
 			// nolint:staticcheck
 			want:    append(fixtures.TrustZone("tz1").AttestationPolicies, fixtures.TrustZone("tz3").AttestationPolicies...),
 			wantErr: false,
@@ -1089,6 +1092,7 @@ func TestLocalDataSource_AddFederation(t *testing.T) {
 				// nolint:staticcheck
 				gotFederation := gotConfig.TrustZones[0].Federations[1]
 				assert.EqualExportedValues(t, tt.federation, gotFederation)
+				assert.NotNil(t, gotFederation.Id)
 			}
 		})
 	}

--- a/pkg/plugin/local/local_test.go
+++ b/pkg/plugin/local/local_test.go
@@ -132,6 +132,7 @@ func TestLocalDataSource_AddTrustZone(t *testing.T) {
 				gotTrustZone, ok := gotConfig.GetTrustZoneByName(tt.trustZone.Name)
 				assert.True(t, ok)
 				assert.EqualExportedValues(t, tt.trustZone, gotTrustZone)
+				assert.NotNil(t, gotTrustZone.Id)
 			}
 		})
 	}


### PR DESCRIPTION
These changes generate a UUID for local resources. This is the same behaviour as with a remote backend which allows the tooling to transition to ID based resource selection.

Fixes https://github.com/cofide/cofidectl/issues/201