### PR TITLE
feat: Add GetHelmValues method to Provision interface

### DIFF
--- a/cmd/cofidectl/cmd/trustzone/helm/helm.go
+++ b/cmd/cofidectl/cmd/trustzone/helm/helm.go
@@ -224,10 +224,12 @@ func (c *HelmCommand) getValues(ctx context.Context, ds datasource.DataSource, t
 		return nil, err
 	}
 
+	slog.Error("getValues cmd", "tzName", tzName, "cluster", cluster.GetName())
 	values, err := provisionPlugin.GetHelmValues(ctx, ds, &provision.GetValuesOpts{
 		TrustZoneName: tzName,
 		ClusterName:   cluster.GetName(),
 	})
+	slog.Error("getValues cmd", "error", err, "values", values)
 	if err != nil {
 		return nil, err
 	}

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.24.2
 require (
 	buf.build/go/protoyaml v0.6.0
 	cuelang.org/go v0.10.1
-	github.com/cofide/cofide-api-sdk v0.18.2
+	github.com/cofide/cofide-api-sdk v0.18.3-0.20250507141234-1d1022da5656
 	github.com/fatih/color v1.18.0
 	github.com/gofrs/flock v0.12.1
 	github.com/google/go-cmp v0.7.0

--- a/go.sum
+++ b/go.sum
@@ -86,8 +86,8 @@ github.com/cncf/xds/go v0.0.0-20211001041855-01bcc9b48dfe/go.mod h1:eXthEFrGJvWH
 github.com/cncf/xds/go v0.0.0-20211011173535-cb28da3451f1/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
 github.com/cockroachdb/apd/v3 v3.2.1 h1:U+8j7t0axsIgvQUqthuNm82HIrYXodOV2iWLWtEaIwg=
 github.com/cockroachdb/apd/v3 v3.2.1/go.mod h1:klXJcjp+FffLTHlhIG69tezTDvdP065naDsHzKhYSqc=
-github.com/cofide/cofide-api-sdk v0.18.2 h1:VympicOPsvPCvZNzVq2Y4U3CaIrBdesTRia+G9dXrbM=
-github.com/cofide/cofide-api-sdk v0.18.2/go.mod h1:wicLuoj7zQ66Hc1tzmB3llt7nVjpSW8gpGj7Wo/YoA4=
+github.com/cofide/cofide-api-sdk v0.18.3-0.20250507141234-1d1022da5656 h1:Rpg0DH9DlVlqrqoTC0XM24ouvVTSr3pVk5ZvkLCY4b0=
+github.com/cofide/cofide-api-sdk v0.18.3-0.20250507141234-1d1022da5656/go.mod h1:wicLuoj7zQ66Hc1tzmB3llt7nVjpSW8gpGj7Wo/YoA4=
 github.com/containerd/cgroups v1.1.0 h1:v8rEWFl6EoqHB+swVNjVoCJE8o3jX7e8nqBGPLaDFBM=
 github.com/containerd/cgroups v1.1.0/go.mod h1:6ppBcbh/NOOUU+dMKrykgaBnK9lCIBxHqJDGwsa1mIw=
 github.com/containerd/containerd v1.7.27 h1:yFyEyojddO3MIGVER2xJLWoCIn+Up4GaHFquP7hsFII=

--- a/pkg/plugin/provision/interface.go
+++ b/pkg/plugin/provision/interface.go
@@ -24,6 +24,9 @@ type Provision interface {
 	// The method is asynchronous, returning a channel over which Status messages are sent
 	// describing the various stages of tear down and their outcomes.
 	TearDown(ctx context.Context, ds datasource.DataSource, opts *TearDownOpts) (<-chan *provisionpb.Status, error)
+
+	// GetHelmValues retrieves the Helm values for the specified trust zone and cluster.
+	GetHelmValues(ctx context.Context, ds datasource.DataSource, opts *GetValuesOpts) (map[string]any, error)
 }
 
 type DeployOpts struct {
@@ -34,4 +37,9 @@ type DeployOpts struct {
 type TearDownOpts struct {
 	KubeCfgFile string
 	TrustZones  []string
+}
+
+type GetValuesOpts struct {
+	TrustZoneName string
+	ClusterName   string
 }

--- a/pkg/plugin/provision/spirehelm/spirehelm.go
+++ b/pkg/plugin/provision/spirehelm/spirehelm.go
@@ -75,6 +75,20 @@ func (h *SpireHelm) TearDown(ctx context.Context, ds datasource.DataSource, opts
 	return statusCh, nil
 }
 
+func (h *SpireHelm) GetHelmValues(ctx context.Context, ds datasource.DataSource, opts *provision.GetValuesOpts) (map[string]any, error) {
+	trustZone, err := ds.GetTrustZone(opts.TrustZoneName)
+	if err != nil {
+		return nil, err
+	}
+
+	cluster, err := ds.GetCluster(opts.ClusterName, opts.TrustZoneName)
+	if err != nil {
+		return nil, err
+	}
+
+	return h.providerFactory.GetHelmValues(ctx, ds, trustZone, cluster)
+}
+
 func (h *SpireHelm) deploy(ctx context.Context, ds datasource.DataSource, opts *provision.DeployOpts, statusCh chan<- *provisionpb.Status) error {
 	trustZoneClusters, err := h.ListTrustZoneClusters(ds, opts.TrustZones)
 	if err != nil {

--- a/pkg/plugin/provision/spirehelm/spirehelm_test.go
+++ b/pkg/plugin/provision/spirehelm/spirehelm_test.go
@@ -160,6 +160,19 @@ func TestSpireHelm_TearDown_specificTrustZone(t *testing.T) {
 	assert.EqualExportedValues(t, want, statuses)
 }
 
+func TestSpireHelm_GetHelmValues(t *testing.T) {
+	providerFactory := newFakeHelmSPIREProviderFactory()
+	spireAPIFactory := newFakeSPIREAPIFactory()
+	spireHelm := NewSpireHelm(providerFactory, spireAPIFactory)
+	ds := newFakeDataSource(t, defaultConfig())
+
+	opts := provision.GetValuesOpts{TrustZoneName: "tz1", ClusterName: "local1"}
+	values, err := spireHelm.GetHelmValues(context.Background(), ds, &opts)
+	require.NoError(t, err, err)
+	want := map[string]any{"key1": "value1", "key2": "value2"}
+	assert.EqualExportedValues(t, want, values)
+}
+
 func collectStatuses(statusCh <-chan *provisionpb.Status) []*provisionpb.Status {
 	statuses := []*provisionpb.Status{}
 	for status := range statusCh {
@@ -182,6 +195,15 @@ func (f *fakeHelmSPIREProviderFactory) Build(
 	genValues bool,
 ) (helm.Provider, error) {
 	return newFakeHelmSPIREProvider(trustZone, cluster), nil
+}
+
+func (f *fakeHelmSPIREProviderFactory) GetHelmValues(
+	ctx context.Context,
+	ds datasource.DataSource,
+	trustZone *trust_zone_proto.TrustZone,
+	cluster *clusterpb.Cluster,
+) (map[string]any, error) {
+	return map[string]any{"key1": "value1", "key2": "value2"}, nil
 }
 
 // fakeHelmSPIREProvider implements a fake helm.Provider that can be used in testing.


### PR DESCRIPTION
This change adds a GetHelmValues method to the Provision interface. This
allows provision plugins to generate their own Helm values for
deployment.

Fixes: #104
