### PR TITLE
feat: Add GetHelmValues method to Provision interface

### DIFF
--- a/cmd/cofidectl/cmd/trustzone/helm/helm.go
+++ b/cmd/cofidectl/cmd/trustzone/helm/helm.go
@@ -4,18 +4,22 @@
 package helm
 
 import (
+	"context"
 	"fmt"
 	"io"
+	"log/slog"
 	"os"
 
 	"github.com/spf13/cobra"
+	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/structpb"
 	"gopkg.in/yaml.v3"
 
+	clusterpb "github.com/cofide/cofide-api-sdk/gen/go/proto/cluster/v1alpha1"
 	"github.com/cofide/cofidectl/internal/pkg/trustzone"
 	cmdcontext "github.com/cofide/cofidectl/pkg/cmd/context"
 	"github.com/cofide/cofidectl/pkg/plugin/datasource"
-	"github.com/cofide/cofidectl/pkg/provider/helm"
+	"github.com/cofide/cofidectl/pkg/plugin/provision"
 )
 
 type HelmCommand struct {
@@ -85,7 +89,7 @@ func (c *HelmCommand) GetOverrideCommand() *cobra.Command {
 				return err
 			}
 
-			return c.overrideValues(ds, args[0], values)
+			return c.overrideValues(cmd.Context(), ds, args[0], values)
 		},
 	}
 
@@ -96,7 +100,12 @@ func (c *HelmCommand) GetOverrideCommand() *cobra.Command {
 }
 
 // overrideValues overrides Helm values for a trust zone.
-func (c *HelmCommand) overrideValues(ds datasource.DataSource, tzName string, values map[string]any) error {
+func (c *HelmCommand) overrideValues(ctx context.Context, ds datasource.DataSource, tzName string, values map[string]any) error {
+	provisionPlugin, err := c.cmdCtx.PluginManager.GetProvision(ctx)
+	if err != nil {
+		return err
+	}
+
 	trustZone, err := ds.GetTrustZone(tzName)
 	if err != nil {
 		return err
@@ -107,19 +116,34 @@ func (c *HelmCommand) overrideValues(ds datasource.DataSource, tzName string, va
 		return err
 	}
 
+	// Make a copy of the cluster to rollback if needed.
+	oldCluster := proto.Clone(cluster).(*clusterpb.Cluster)
+
 	cluster.ExtraHelmValues, err = structpb.NewStruct(values)
 	if err != nil {
 		return err
 	}
 
-	// Check that the values are acceptable.
-	generator := helm.NewHelmValuesGenerator(trustZone, cluster, ds, nil)
-	if _, err = generator.GenerateValues(); err != nil {
+	_, err = ds.UpdateCluster(cluster)
+	if err != nil {
 		return err
 	}
 
-	_, err = ds.UpdateCluster(cluster)
-	return err
+	// Check that the values are acceptable.
+	_, err = provisionPlugin.GetHelmValues(ctx, ds, &provision.GetHelmValuesOpts{
+		TrustZoneName: tzName,
+		ClusterName:   cluster.GetName(),
+	})
+	if err != nil {
+		slog.Error("Failed to generate Helm values, rolling back", "error", err)
+		// Rollback the cluster to the old state.
+		_, rollbackErr := ds.UpdateCluster(oldCluster)
+		if rollbackErr != nil {
+			return fmt.Errorf("failed to rollback cluster: %w", rollbackErr)
+		}
+		return err
+	}
+	return nil
 }
 
 // readValues reads values in YAML format from the specified reader.
@@ -151,7 +175,7 @@ func (c *HelmCommand) GetValuesCommand() *cobra.Command {
 				return err
 			}
 
-			values, err := c.getValues(ds, args[0])
+			values, err := c.getValues(cmd.Context(), ds, args[0])
 			if err != nil {
 				return err
 			}
@@ -184,7 +208,7 @@ func (c *HelmCommand) GetValuesCommand() *cobra.Command {
 }
 
 // getValues returns the Helm values for a trust zone.
-func (c *HelmCommand) getValues(ds datasource.DataSource, tzName string) (map[string]any, error) {
+func (c *HelmCommand) getValues(ctx context.Context, ds datasource.DataSource, tzName string) (map[string]any, error) {
 	trustZone, err := ds.GetTrustZone(tzName)
 	if err != nil {
 		return nil, err
@@ -195,8 +219,15 @@ func (c *HelmCommand) getValues(ds datasource.DataSource, tzName string) (map[st
 		return nil, err
 	}
 
-	generator := helm.NewHelmValuesGenerator(trustZone, cluster, ds, nil)
-	values, err := generator.GenerateValues()
+	provisionPlugin, err := c.cmdCtx.PluginManager.GetProvision(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	values, err := provisionPlugin.GetHelmValues(ctx, ds, &provision.GetHelmValuesOpts{
+		TrustZoneName: tzName,
+		ClusterName:   cluster.GetName(),
+	})
 	if err != nil {
 		return nil, err
 	}

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.24.2
 require (
 	buf.build/go/protoyaml v0.6.0
 	cuelang.org/go v0.10.1
-	github.com/cofide/cofide-api-sdk v0.18.2
+	github.com/cofide/cofide-api-sdk v0.19.0
 	github.com/fatih/color v1.18.0
 	github.com/gofrs/flock v0.12.1
 	github.com/google/go-cmp v0.7.0

--- a/go.sum
+++ b/go.sum
@@ -86,8 +86,8 @@ github.com/cncf/xds/go v0.0.0-20211001041855-01bcc9b48dfe/go.mod h1:eXthEFrGJvWH
 github.com/cncf/xds/go v0.0.0-20211011173535-cb28da3451f1/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
 github.com/cockroachdb/apd/v3 v3.2.1 h1:U+8j7t0axsIgvQUqthuNm82HIrYXodOV2iWLWtEaIwg=
 github.com/cockroachdb/apd/v3 v3.2.1/go.mod h1:klXJcjp+FffLTHlhIG69tezTDvdP065naDsHzKhYSqc=
-github.com/cofide/cofide-api-sdk v0.18.2 h1:VympicOPsvPCvZNzVq2Y4U3CaIrBdesTRia+G9dXrbM=
-github.com/cofide/cofide-api-sdk v0.18.2/go.mod h1:wicLuoj7zQ66Hc1tzmB3llt7nVjpSW8gpGj7Wo/YoA4=
+github.com/cofide/cofide-api-sdk v0.19.0 h1:QAfbqkSw6SxCWsOLMjPtzrxuPHIQsVv9Ne7ED4zcIwc=
+github.com/cofide/cofide-api-sdk v0.19.0/go.mod h1:wicLuoj7zQ66Hc1tzmB3llt7nVjpSW8gpGj7Wo/YoA4=
 github.com/containerd/cgroups v1.1.0 h1:v8rEWFl6EoqHB+swVNjVoCJE8o3jX7e8nqBGPLaDFBM=
 github.com/containerd/cgroups v1.1.0/go.mod h1:6ppBcbh/NOOUU+dMKrykgaBnK9lCIBxHqJDGwsa1mIw=
 github.com/containerd/containerd v1.7.27 h1:yFyEyojddO3MIGVER2xJLWoCIn+Up4GaHFquP7hsFII=

--- a/pkg/plugin/provision/interface.go
+++ b/pkg/plugin/provision/interface.go
@@ -24,6 +24,9 @@ type Provision interface {
 	// The method is asynchronous, returning a channel over which Status messages are sent
 	// describing the various stages of tear down and their outcomes.
 	TearDown(ctx context.Context, ds datasource.DataSource, opts *TearDownOpts) (<-chan *provisionpb.Status, error)
+
+	// GetHelmValues retrieves the Helm values for the specified trust zone and cluster.
+	GetHelmValues(ctx context.Context, ds datasource.DataSource, opts *GetHelmValuesOpts) (map[string]any, error)
 }
 
 type DeployOpts struct {
@@ -34,4 +37,9 @@ type DeployOpts struct {
 type TearDownOpts struct {
 	KubeCfgFile string
 	TrustZones  []string
+}
+
+type GetHelmValuesOpts struct {
+	TrustZoneName string
+	ClusterName   string
 }

--- a/pkg/plugin/provision/plugin.go
+++ b/pkg/plugin/provision/plugin.go
@@ -5,6 +5,7 @@ package provision
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 
@@ -14,6 +15,7 @@ import (
 	go_plugin "github.com/hashicorp/go-plugin"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/types/known/structpb"
 )
 
 // ProvisionPluginName is the name that should be used in the plugin map.
@@ -118,6 +120,24 @@ func (c *ProvisionPluginClientGRPC) TearDown(ctx context.Context, source datasou
 	}()
 
 	return statusCh, nil
+}
+
+func (c *ProvisionPluginClientGRPC) GetHelmValues(ctx context.Context, source datasource.DataSource, opts *GetHelmValuesOpts) (map[string]any, error) {
+	server, brokerID := c.startDataSourceServer(source)
+	defer server.Stop()
+
+	req := provisionpb.GetHelmValuesRequest{
+		DataSource:    &brokerID,
+		TrustZoneName: &opts.TrustZoneName,
+		ClusterName:   &opts.ClusterName,
+	}
+	resp, err := c.client.GetHelmValues(ctx, &req)
+	if err != nil {
+		err := wrapError(err)
+		return nil, err
+	}
+
+	return resp.GetHelmValues().AsMap(), nil
 }
 
 // startDataSourceServer returns a grpc.Server and associated broker ID, allowing for bidirectional
@@ -230,6 +250,48 @@ func (s *GRPCServer) TearDown(req *provisionpb.TearDownRequest, stream grpc.Serv
 		}
 	}
 	return nil
+}
+
+func (s *GRPCServer) GetHelmValues(ctx context.Context, req *provisionpb.GetHelmValuesRequest) (*provisionpb.GetHelmValuesResponse, error) {
+	client, conn, err := s.getDataSourceClient(ctx, req.GetDataSource())
+	if err != nil {
+		return nil, err
+	}
+	defer conn.Close()
+
+	opts := GetHelmValuesOpts{
+		TrustZoneName: req.GetTrustZoneName(),
+		ClusterName:   req.GetClusterName(),
+	}
+	values, err := s.impl.GetHelmValues(ctx, client, &opts)
+	if err != nil {
+		return nil, err
+	}
+
+	helmValues, err := valuesToStruct(values)
+	if err != nil {
+		return nil, err
+	}
+
+	return &provisionpb.GetHelmValuesResponse{HelmValues: helmValues}, nil
+}
+
+// valuesToStruct creates a *Struct representing a set of Helm values from a map[string]any.
+// It performs a round trip JSON encode/decode, ensuring that the values are in a format compatible
+// with structpb.Struct. See https://github.com/golang/protobuf/issues/1302.
+func valuesToStruct(values map[string]any) (*structpb.Struct, error) {
+	valuesJSON, err := json.Marshal(values)
+	if err != nil {
+		return nil, err
+	}
+
+	var result map[string]any
+	err = json.Unmarshal(valuesJSON, &result)
+	if err != nil {
+		return nil, err
+	}
+
+	return structpb.NewStruct(result)
 }
 
 // getDataSourceClient returns a DataSource and associated gRPC connection, allowing for

--- a/pkg/plugin/provision/plugin_test.go
+++ b/pkg/plugin/provision/plugin_test.go
@@ -1,0 +1,61 @@
+// Copyright 2025 Cofide Limited.
+// SPDX-License-Identifier: Apache-2.0
+
+package provision
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/types/known/structpb"
+)
+
+func Test_valuesToStruct(t *testing.T) {
+	tests := []struct {
+		name         string
+		values       map[string]any
+		want         *structpb.Struct
+		breaksStruct bool
+	}{
+		{
+			name:   "empty map",
+			values: map[string]any{},
+			want: func() *structpb.Struct {
+				s, err := structpb.NewStruct(nil)
+				require.NoError(t, err)
+				return s
+			}(),
+		},
+		{
+			name: "breaks struct",
+			values: map[string]any{
+				"foo": "bar",
+				// []string is not supported by Struct. JSON round trip converts this to []any.
+				"baz": []string{"qux"},
+			},
+			want: func() *structpb.Struct {
+				s, err := structpb.NewStruct(map[string]any{
+					"foo": "bar",
+					"baz": []any{"qux"},
+				})
+				require.NoError(t, err)
+				return s
+			}(),
+			breaksStruct: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := valuesToStruct(tt.values)
+			require.NoError(t, err)
+			assert.EqualExportedValues(t, tt.want, got)
+
+			if tt.breaksStruct {
+				// Confirm that these values are not natively supported by Struct.
+				_, err := structpb.NewStruct(tt.values)
+				require.Error(t, err)
+			}
+		})
+	}
+}

--- a/pkg/plugin/provision/spirehelm/spirehelm.go
+++ b/pkg/plugin/provision/spirehelm/spirehelm.go
@@ -75,6 +75,20 @@ func (h *SpireHelm) TearDown(ctx context.Context, ds datasource.DataSource, opts
 	return statusCh, nil
 }
 
+func (h *SpireHelm) GetHelmValues(ctx context.Context, ds datasource.DataSource, opts *provision.GetHelmValuesOpts) (map[string]any, error) {
+	trustZone, err := ds.GetTrustZone(opts.TrustZoneName)
+	if err != nil {
+		return nil, err
+	}
+
+	cluster, err := ds.GetCluster(opts.ClusterName, opts.TrustZoneName)
+	if err != nil {
+		return nil, err
+	}
+
+	return h.providerFactory.GetHelmValues(ctx, ds, trustZone, cluster)
+}
+
 func (h *SpireHelm) deploy(ctx context.Context, ds datasource.DataSource, opts *provision.DeployOpts, statusCh chan<- *provisionpb.Status) error {
 	trustZoneClusters, err := h.ListTrustZoneClusters(ds, opts.TrustZones)
 	if err != nil {

--- a/pkg/plugin/provision/spirehelm/spirehelm_test.go
+++ b/pkg/plugin/provision/spirehelm/spirehelm_test.go
@@ -160,6 +160,19 @@ func TestSpireHelm_TearDown_specificTrustZone(t *testing.T) {
 	assert.EqualExportedValues(t, want, statuses)
 }
 
+func TestSpireHelm_GetHelmValues(t *testing.T) {
+	providerFactory := newFakeHelmSPIREProviderFactory()
+	spireAPIFactory := newFakeSPIREAPIFactory()
+	spireHelm := NewSpireHelm(providerFactory, spireAPIFactory)
+	ds := newFakeDataSource(t, defaultConfig())
+
+	opts := provision.GetHelmValuesOpts{TrustZoneName: "tz1", ClusterName: "local1"}
+	values, err := spireHelm.GetHelmValues(context.Background(), ds, &opts)
+	require.NoError(t, err, err)
+	want := map[string]any{"key1": "value1", "key2": "value2"}
+	assert.EqualExportedValues(t, want, values)
+}
+
 func collectStatuses(statusCh <-chan *provisionpb.Status) []*provisionpb.Status {
 	statuses := []*provisionpb.Status{}
 	for status := range statusCh {
@@ -182,6 +195,15 @@ func (f *fakeHelmSPIREProviderFactory) Build(
 	genValues bool,
 ) (helm.Provider, error) {
 	return newFakeHelmSPIREProvider(trustZone, cluster), nil
+}
+
+func (f *fakeHelmSPIREProviderFactory) GetHelmValues(
+	ctx context.Context,
+	ds datasource.DataSource,
+	trustZone *trust_zone_proto.TrustZone,
+	cluster *clusterpb.Cluster,
+) (map[string]any, error) {
+	return map[string]any{"key1": "value1", "key2": "value2"}, nil
 }
 
 // fakeHelmSPIREProvider implements a fake helm.Provider that can be used in testing.

--- a/tests/integration/federation/test.sh
+++ b/tests/integration/federation/test.sh
@@ -81,6 +81,11 @@ function list_resources() {
   ./cofidectl attestation-policy-binding list
 }
 
+function show_helm_values() {
+  ./cofidectl trust-zone helm values $TRUST_ZONE_1 --output-file -
+  ./cofidectl trust-zone helm values $TRUST_ZONE_2 --output-file -
+}
+
 function show_config() {
   cat cofide.yaml
 }
@@ -175,6 +180,7 @@ function main() {
   up
   check_spire
   list_resources
+  show_helm_values
   show_config
   show_status
   run_tests


### PR DESCRIPTION
This change adds a GetHelmValues method to the Provision interface. This
allows provision plugins to generate their own Helm values for
deployment.

Fixes: #104
