### PR TITLE
fix: add a --force argument to trust zone and cluster delete

### DIFF
--- a/cmd/cofidectl/cmd/federation/federation.go
+++ b/cmd/cofidectl/cmd/federation/federation.go
@@ -147,6 +147,10 @@ func checkFederationStatus(ctx context.Context, ds datasource.DataSource, kubeCo
 			return "", "", err
 		}
 
+		if err := helm.IsClusterReachable(ctx, cluster, kubeConfig); err != nil {
+			return "Unknown", err.Error(), nil
+		}
+
 		if deployed, err := helm.IsClusterDeployed(ctx, cluster, kubeConfig); err != nil {
 			return "", "", err
 		} else if !deployed {

--- a/cmd/cofidectl/cmd/trustzone/trustzone_test.go
+++ b/cmd/cofidectl/cmd/trustzone/trustzone_test.go
@@ -141,7 +141,7 @@ func TestTrustZoneCommand_deleteTrustZone(t *testing.T) {
 			if tt.injectFailure {
 				ds = &failingDS{LocalDataSource: ds.(*local.LocalDataSource)}
 			}
-			err := deleteTrustZone(context.Background(), tt.trustZoneName, ds, false, "")
+			err := deleteTrustZone(context.Background(), tt.trustZoneName, ds, "", true)
 			if tt.wantErr {
 				require.Error(t, err)
 				assert.ErrorContains(t, err, tt.wantErrMessage)

--- a/cmd/cofidectl/cmd/workload/workload.go
+++ b/cmd/cofidectl/cmd/workload/workload.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log/slog"
 	"os"
 
 	provisionpb "github.com/cofide/cofide-api-sdk/gen/go/proto/provision_plugin/v1alpha1"
@@ -203,6 +204,11 @@ func renderRegisteredWorkloads(ctx context.Context, ds datasource.DataSource, ku
 			return err
 		}
 
+		if err := helm.IsClusterReachable(ctx, cluster, kubeConfig); err != nil {
+			slog.Warn("Cluster is unreachable", "cluster", cluster.GetName(), "error", err)
+			continue
+		}
+
 		if deployed, err := helm.IsClusterDeployed(ctx, cluster, kubeConfig); err != nil {
 			return err
 		} else if !deployed {
@@ -322,6 +328,11 @@ func renderUnregisteredWorkloads(ctx context.Context, ds datasource.DataSource, 
 				continue
 			}
 			return err
+		}
+
+		if err := helm.IsClusterReachable(ctx, cluster, kubeConfig); err != nil {
+			slog.Warn("Cluster is unreachable", "cluster", cluster.GetName(), "error", err)
+			continue
 		}
 
 		deployed, err := helm.IsClusterDeployed(ctx, cluster, kubeConfig)

--- a/pkg/provider/helm/helm.go
+++ b/pkg/provider/helm/helm.go
@@ -241,6 +241,11 @@ func (h *HelmSPIREProvider) ExecuteUninstall(statusCh chan<- *provisionpb.Status
 	return nil
 }
 
+// CheckIfReachable returns no error if a Kubernetes cluster is reachable.
+func (h *HelmSPIREProvider) CheckIfReachable() error {
+	return h.cfg.KubeClient.IsReachable()
+}
+
 // CheckIfAlreadyInstalled returns true if the SPIRE chart has previously been installed.
 func (h *HelmSPIREProvider) CheckIfAlreadyInstalled() (bool, error) {
 	return checkIfAlreadyInstalled(h.cfg, SPIREChartName)
@@ -412,6 +417,15 @@ func checkIfAlreadyInstalled(cfg *action.Configuration, chartName string) (bool,
 		return false, err
 	}
 	return len(ledger) > 0, nil
+}
+
+// IsClusterDeployed returns whether a Kubernetes cluster is reachable.
+func IsClusterReachable(ctx context.Context, cluster *clusterpb.Cluster, kubeConfig string) error {
+	prov, err := NewHelmSPIREProvider(ctx, cluster, nil, nil, kubeConfig)
+	if err != nil {
+		return err
+	}
+	return prov.CheckIfReachable()
 }
 
 // IsClusterDeployed returns whether a cluster has been deployed, i.e. whether a SPIRE Helm release has been installed.


### PR DESCRIPTION
If a Kubernetes cluster has been deleted, then previously it was not
possible to delete the corresponding cofidectl cluster and trust zone
because the Helm chart installation check would fail.

This change provides a workaround with a --force flag that skips the pre-delete checks.

Fixes: #225
