### PR TITLE
fix: install Helm secrets into spire-mgmt namespace

### DIFF
--- a/pkg/provider/helm/helm.go
+++ b/pkg/provider/helm/helm.go
@@ -58,6 +58,7 @@ type HelmSPIREProvider struct {
 func NewHelmSPIREProvider(ctx context.Context, cluster *clusterpb.Cluster, spireValues, spireCRDsValues map[string]any) (*HelmSPIREProvider, error) {
 	settings := cli.New()
 	settings.KubeContext = cluster.GetKubernetesContext()
+	settings.SetNamespace(SPIREManagementNamespace)
 
 	prov := &HelmSPIREProvider{
 		ctx:              ctx,

--- a/tests/integration/single-trust-zone/test.sh
+++ b/tests/integration/single-trust-zone/test.sh
@@ -129,7 +129,7 @@ function check_overridden_values() {
 }
 
 function check_overridden_value() {
-  value=$(helm --kube-context $K8S_CLUSTER_CONTEXT get values spire | yq $1)
+  value=$(helm --kube-context $K8S_CLUSTER_CONTEXT get values spire --namespace spire-mgmt | yq $1)
   if [[ $value != $2 ]]; then
     echo "Error: Did not find expected overridden Helm value $1: expected $2, actual $value"
     return 1


### PR DESCRIPTION
When running cofidectl up, the secrets for the spire and spire-crds Helm
releases were previously installed into the default namespace, rather
than the expected spire-mgmt namespace:

kubectl get secrets -n default
NAMESPACE     NAME                                 TYPE                            DATA   AGE
default       sh.helm.release.v1.spire-crds.v1     helm.sh/release.v1              1      38m
default       sh.helm.release.v1.spire.v1          helm.sh/release.v1              1      38m

This is confusing because the Helm release list command showed the
releases as being in the spire-mgmt namespace:

helm list -A
NAME        	NAMESPACE 	REVISION	UPDATED                                	STATUS  	CHART             	APP VERSION
spire       	spire-mgmt	1       	2025-05-08 09:34:01.860454781 +0100 BST	deployed	spire-0.21.0      	1.9.6
spire-crds  	spire-mgmt	1       	2025-05-08 09:33:57.185244927 +0100 BST	deployed	spire-crds-0.4.0  	0.0.1

This change fixes the issue by setting the spire-mgmt namespace on the
Helm EnvSettings.

Running cofidectl up with this change on a cluster deployed prior to
this change will result in a duplicate Helm release being created. This
does not appear to cause a problem - the managed resources have their
release-namespace label updated to spire-mgmt.

Fixes: #227
