### PR TITLE
fix: federation deletion with local data source

### DIFF
--- a/pkg/plugin/local/local.go
+++ b/pkg/plugin/local/local.go
@@ -587,7 +587,9 @@ func (lds *LocalDataSource) DestroyFederation(federation *federation_proto.Feder
 
 	// nolint:staticcheck
 	for i, fed := range trustZone.Federations {
-		if proto.FederationsEqual(fed, federation) {
+		// We cannot compare the protos directly here because the ones in the config have IDs.
+		// nolint:staticcheck
+		if fed.From == federation.From && fed.To == federation.To {
 			// nolint:staticcheck
 			trustZone.Federations = append(trustZone.Federations[:i], trustZone.Federations[i+1:]...)
 			if err := lds.updateDataFile(); err != nil {


### PR DESCRIPTION
The addition of two features conflicted and was not caught in CI:

- federation deletion
- resource IDs in the local data source

The addition of resource IDs broke the proto comparison, because the CLI
does not yet understand or use IDs.

This change fixes the issue by comparing the From and To fields
directly.
