### PR TITLE
chore: Bump SPIRE Helm chart versions

### DIFF
--- a/internal/pkg/trustprovider/trustprovider.go
+++ b/internal/pkg/trustprovider/trustprovider.go
@@ -12,7 +12,7 @@ import (
 
 const (
 	KubernetesTrustProvider string = "k8s"
-	kubernetesPsat          string = "k8sPsat"
+	kubernetesPSAT          string = "k8sPSAT"
 )
 
 type TrustProvider struct {
@@ -44,10 +44,10 @@ func (tp *TrustProvider) getValues() error {
 				"enabled":                   true,
 				"disableContainerSelectors": true,
 			},
-			NodeAttestor: kubernetesPsat,
+			NodeAttestor: kubernetesPSAT,
 		}
 		tp.ServerConfig = TrustProviderServerConfig{
-			NodeAttestor: kubernetesPsat,
+			NodeAttestor: kubernetesPSAT,
 			NodeAttestorConfig: map[string]any{
 				"enabled":  true,
 				"audience": []string{"spire-server"},

--- a/pkg/provider/helm/helm.go
+++ b/pkg/provider/helm/helm.go
@@ -30,9 +30,9 @@ const (
 	SPIRERepositoryUrl  = "https://spiffe.github.io/helm-charts-hardened/"
 
 	SPIREChartName        = "spire"
-	SPIREChartVersion     = "0.21.0"
+	SPIREChartVersion     = "0.24.5"
 	SPIRECRDsChartName    = "spire-crds"
-	SPIRECRDsChartVersion = "0.4.0"
+	SPIRECRDsChartVersion = "0.5.0"
 
 	// Kubernetes namespace in which Helm charts and CRDs will be installed.
 	SPIREManagementNamespace = "spire-mgmt"

--- a/pkg/provider/helm/helm_test.go
+++ b/pkg/provider/helm/helm_test.go
@@ -21,8 +21,8 @@ func TestHelmSPIREProvider(t *testing.T) {
 
 	p, err := NewHelmSPIREProvider(context.Background(), cluster, spireValues, spireCRDsValues, kubeConfig)
 	assert.Nil(t, err)
-	assert.Equal(t, p.SPIREVersion, "0.21.0")
-	assert.Equal(t, p.SPIRECRDsVersion, "0.4.0")
+	assert.Equal(t, p.SPIREVersion, "0.24.5")
+	assert.Equal(t, p.SPIRECRDsVersion, "0.5.0")
 	assert.Equal(t, cluster.GetName(), p.cluster.GetName())
 	assert.Equal(t, kubeConfig, p.settings.KubeConfig)
 }

--- a/pkg/provider/helm/values.go
+++ b/pkg/provider/helm/values.go
@@ -17,10 +17,10 @@ import (
 )
 
 const (
-	k8sPsatSelectorType                = "k8s_psat"
-	k8sPsatSPIREAgentNamespaceSelector = "agent_ns"
-	k8sPsatSPIREAgentSASelector        = "agent_sa"
-	k8sPsatClusterSelector             = "cluster"
+	k8sPSATSelectorType                = "k8s_psat"
+	k8sPSATSPIREAgentNamespaceSelector = "agent_ns"
+	k8sPSATSPIREAgentSASelector        = "agent_sa"
+	k8sPSATClusterSelector             = "cluster"
 	serverIdPath                       = "/spire/server"
 	spireAgentNamespace                = "spire-system"
 	spireAgentSA                       = "spire-agent"
@@ -215,9 +215,9 @@ func (g *HelmValuesGenerator) GenerateValues() (map[string]any, error) {
 			"parentID": fmt.Sprintf("spiffe://%s%s", g.trustZone.GetTrustDomain(), serverIdPath),
 			"spiffeID": fmt.Sprintf("spiffe://%s/cluster/%s/spire/agents", g.trustZone.GetTrustDomain(), g.cluster.GetName()),
 			"selectors": []string{
-				fmt.Sprintf("%s:%s:%s", k8sPsatSelectorType, k8sPsatSPIREAgentNamespaceSelector, spireAgentNamespace),
-				fmt.Sprintf("%s:%s:%s", k8sPsatSelectorType, k8sPsatSPIREAgentSASelector, spireAgentSA),
-				fmt.Sprintf("%s:%s:%s", k8sPsatSelectorType, k8sPsatClusterSelector, g.cluster.GetName()),
+				fmt.Sprintf("%s:%s:%s", k8sPSATSelectorType, k8sPSATSPIREAgentNamespaceSelector, spireAgentNamespace),
+				fmt.Sprintf("%s:%s:%s", k8sPSATSelectorType, k8sPSATSPIREAgentSASelector, spireAgentSA),
+				fmt.Sprintf("%s:%s:%s", k8sPSATSelectorType, k8sPSATClusterSelector, g.cluster.GetName()),
 			},
 		}
 	}
@@ -574,7 +574,7 @@ func getSDSConfig(profile string) (map[string]any, error) {
 		// https://istio.io/latest/docs/ops/integrations/spire/#spiffe-federation
 		return map[string]any{
 			"enabled":               true,
-			"defaultSvidName":       "default",
+			"defaultSVIDName":       "default",
 			"defaultBundleName":     "null",
 			"defaultAllBundlesName": "ROOTCA",
 		}, nil
@@ -582,7 +582,7 @@ func getSDSConfig(profile string) (map[string]any, error) {
 		// https://github.com/spiffe/spire/blob/main/doc/spire_agent.md#sds-configuration
 		return map[string]any{
 			"enabled":               true,
-			"defaultSvidName":       "default",
+			"defaultSVIDName":       "default",
 			"defaultBundleName":     "ROOTCA",
 			"defaultAllBundlesName": "ALL",
 		}, nil

--- a/pkg/provider/helm/values_test.go
+++ b/pkg/provider/helm/values_test.go
@@ -84,13 +84,13 @@ func TestHelmValuesGenerator_GenerateValues_success(t *testing.T) {
 					"fullnameOverride": "spire-agent",
 					"logLevel":         "DEBUG",
 					"nodeAttestor": Values{
-						"k8sPsat": Values{
+						"k8sPSAT": Values{
 							"enabled": true,
 						},
 					},
 					"sds": map[string]any{
 						"enabled":               true,
-						"defaultSvidName":       "default",
+						"defaultSVIDName":       "default",
 						"defaultBundleName":     "ROOTCA",
 						"defaultAllBundlesName": "ALL",
 					},
@@ -119,7 +119,7 @@ func TestHelmValuesGenerator_GenerateValues_success(t *testing.T) {
 					"fullnameOverride": "spire-server",
 					"logLevel":         "DEBUG",
 					"nodeAttestor": Values{
-						"k8sPsat": Values{
+						"k8sPSAT": Values{
 							"audience": []string{"spire-server"},
 							"enabled":  true,
 						},
@@ -169,13 +169,13 @@ func TestHelmValuesGenerator_GenerateValues_success(t *testing.T) {
 					"fullnameOverride": "spire-agent",
 					"logLevel":         "DEBUG",
 					"nodeAttestor": Values{
-						"k8sPsat": Values{
+						"k8sPSAT": Values{
 							"enabled": true,
 						},
 					},
 					"sds": map[string]any{
 						"enabled":               true,
-						"defaultSvidName":       "default",
+						"defaultSVIDName":       "default",
 						"defaultBundleName":     "ROOTCA",
 						"defaultAllBundlesName": "ALL",
 					},
@@ -228,7 +228,7 @@ func TestHelmValuesGenerator_GenerateValues_success(t *testing.T) {
 					"logLevel":         "INFO",
 					"nameOverride":     "custom-server-name",
 					"nodeAttestor": Values{
-						"k8sPsat": Values{
+						"k8sPSAT": Values{
 							"audience": []string{"spire-server"},
 							"enabled":  true,
 						},
@@ -278,13 +278,13 @@ func TestHelmValuesGenerator_GenerateValues_success(t *testing.T) {
 					"fullnameOverride": "spire-agent",
 					"logLevel":         "DEBUG",
 					"nodeAttestor": Values{
-						"k8sPsat": Values{
+						"k8sPSAT": Values{
 							"enabled": true,
 						},
 					},
 					"sds": map[string]any{
 						"enabled":               true,
-						"defaultSvidName":       "default",
+						"defaultSVIDName":       "default",
 						"defaultBundleName":     "ROOTCA",
 						"defaultAllBundlesName": "ALL",
 					},
@@ -342,7 +342,7 @@ func TestHelmValuesGenerator_GenerateValues_success(t *testing.T) {
 					"fullnameOverride": "spire-server",
 					"logLevel":         "DEBUG",
 					"nodeAttestor": Values{
-						"k8sPsat": Values{
+						"k8sPSAT": Values{
 							"audience": []string{"spire-server"},
 							"enabled":  true,
 						},
@@ -391,13 +391,13 @@ func TestHelmValuesGenerator_GenerateValues_success(t *testing.T) {
 					"fullnameOverride": "spire-agent",
 					"logLevel":         "DEBUG",
 					"nodeAttestor": Values{
-						"k8sPsat": Values{
+						"k8sPSAT": Values{
 							"enabled": true,
 						},
 					},
 					"sds": map[string]any{
 						"enabled":               true,
-						"defaultSvidName":       "default",
+						"defaultSVIDName":       "default",
 						"defaultBundleName":     "null",
 						"defaultAllBundlesName": "ROOTCA",
 					},
@@ -426,7 +426,7 @@ func TestHelmValuesGenerator_GenerateValues_success(t *testing.T) {
 					"fullnameOverride": "spire-server",
 					"logLevel":         "DEBUG",
 					"nodeAttestor": Values{
-						"k8sPsat": Values{
+						"k8sPSAT": Values{
 							"audience": []string{"spire-server"},
 							"enabled":  true,
 						},
@@ -476,13 +476,13 @@ func TestHelmValuesGenerator_GenerateValues_success(t *testing.T) {
 					"fullnameOverride": "spire-agent",
 					"logLevel":         "DEBUG",
 					"nodeAttestor": Values{
-						"k8sPsat": Values{
+						"k8sPSAT": Values{
 							"enabled": true,
 						},
 					},
 					"sds": map[string]any{
 						"enabled":               true,
-						"defaultSvidName":       "default",
+						"defaultSVIDName":       "default",
 						"defaultBundleName":     "ROOTCA",
 						"defaultAllBundlesName": "ALL",
 					},
@@ -622,13 +622,13 @@ func TestHelmValuesGenerator_GenerateValues_AdditionalValues(t *testing.T) {
 					"fullnameOverride": "spire-agent",
 					"logLevel":         "DEBUG",
 					"nodeAttestor": Values{
-						"k8sPsat": Values{
+						"k8sPSAT": Values{
 							"enabled": true,
 						},
 					},
 					"sds": map[string]any{
 						"enabled":               true,
-						"defaultSvidName":       "default",
+						"defaultSVIDName":       "default",
 						"defaultBundleName":     "ROOTCA",
 						"defaultAllBundlesName": "ALL",
 					},
@@ -666,7 +666,7 @@ func TestHelmValuesGenerator_GenerateValues_AdditionalValues(t *testing.T) {
 					"fullnameOverride": "spire-server",
 					"logLevel":         "DEBUG",
 					"nodeAttestor": Values{
-						"k8sPsat": Values{
+						"k8sPSAT": Values{
 							"audience": []string{"spire-server"},
 							"enabled":  true,
 						},
@@ -1325,11 +1325,11 @@ func TestSpireAgentValues_GenerateValues(t *testing.T) {
 						"enabled":                   true,
 						"disableContainerSelectors": true,
 					},
-					NodeAttestor: "k8sPsat",
+					NodeAttestor: "k8sPSAT",
 				},
 				sdsConfig: map[string]any{
 					"enabled":               true,
-					"defaultSvidName":       "default",
+					"defaultSVIDName":       "default",
 					"defaultBundleName":     "ROOTCA",
 					"defaultAllBundlesName": "ALL",
 				},
@@ -1339,13 +1339,13 @@ func TestSpireAgentValues_GenerateValues(t *testing.T) {
 					"fullnameOverride": "spire-agent",
 					"logLevel":         "DEBUG",
 					"nodeAttestor": map[string]any{
-						"k8sPsat": map[string]any{
+						"k8sPSAT": map[string]any{
 							"enabled": true,
 						},
 					},
 					"sds": map[string]any{
 						"enabled":               true,
-						"defaultSvidName":       "default",
+						"defaultSVIDName":       "default",
 						"defaultBundleName":     "ROOTCA",
 						"defaultAllBundlesName": "ALL",
 					},
@@ -1369,11 +1369,11 @@ func TestSpireAgentValues_GenerateValues(t *testing.T) {
 						"enabled":                   true,
 						"disableContainerSelectors": true,
 					},
-					NodeAttestor: "k8sPsat",
+					NodeAttestor: "k8sPSAT",
 				},
 				sdsConfig: map[string]any{
 					"enabled":               true,
-					"defaultSvidName":       "default",
+					"defaultSVIDName":       "default",
 					"defaultBundleName":     "ROOTCA",
 					"defaultAllBundlesName": "ALL",
 				},
@@ -1390,11 +1390,11 @@ func TestSpireAgentValues_GenerateValues(t *testing.T) {
 				agentConfig: trustprovider.TrustProviderAgentConfig{
 					WorkloadAttestor:       "k8s",
 					WorkloadAttestorConfig: map[string]any{},
-					NodeAttestor:           "k8sPsat",
+					NodeAttestor:           "k8sPSAT",
 				},
 				sdsConfig: map[string]any{
 					"enabled":               true,
-					"defaultSvidName":       "default",
+					"defaultSVIDName":       "default",
 					"defaultBundleName":     "ROOTCA",
 					"defaultAllBundlesName": "ALL",
 				},
@@ -1414,11 +1414,11 @@ func TestSpireAgentValues_GenerateValues(t *testing.T) {
 						"enabled":                   true,
 						"disableContainerSelectors": true,
 					},
-					NodeAttestor: "k8sPsat",
+					NodeAttestor: "k8sPSAT",
 				},
 				sdsConfig: map[string]any{
 					"enabled":               true,
-					"defaultSvidName":       "default",
+					"defaultSVIDName":       "default",
 					"defaultBundleName":     "ROOTCA",
 					"defaultAllBundlesName": "ALL",
 				},
@@ -1438,7 +1438,7 @@ func TestSpireAgentValues_GenerateValues(t *testing.T) {
 						"enabled":                   true,
 						"disableContainerSelectors": true,
 					},
-					NodeAttestor: "k8sPsat",
+					NodeAttestor: "k8sPSAT",
 				},
 				sdsConfig: map[string]any{},
 			},
@@ -1457,7 +1457,7 @@ func TestSpireAgentValues_GenerateValues(t *testing.T) {
 						"enabled":                   true,
 						"disableContainerSelectors": true,
 					},
-					NodeAttestor: "k8sPsat",
+					NodeAttestor: "k8sPSAT",
 				},
 				sdsConfig: nil,
 			},
@@ -1498,7 +1498,7 @@ func TestSpireServerValues_GenerateValues(t *testing.T) {
 				fullnameOverride:         "spire-server",
 				logLevel:                 "DEBUG",
 				serverConfig: trustprovider.TrustProviderServerConfig{
-					NodeAttestor: "k8sPsat",
+					NodeAttestor: "k8sPSAT",
 					NodeAttestorConfig: map[string]any{
 						"enabled":  true,
 						"audience": []string{"spire-server"},
@@ -1517,7 +1517,7 @@ func TestSpireServerValues_GenerateValues(t *testing.T) {
 					"fullnameOverride": "spire-server",
 					"logLevel":         "DEBUG",
 					"nodeAttestor": Values{
-						"k8sPsat": Values{
+						"k8sPSAT": Values{
 							"audience": []string{"spire-server"},
 							"enabled":  true,
 						},
@@ -1551,7 +1551,7 @@ func TestSpireServerValues_GenerateValues(t *testing.T) {
 				fullnameOverride:         "spire-server",
 				logLevel:                 "DEBUG",
 				serverConfig: trustprovider.TrustProviderServerConfig{
-					NodeAttestor: "k8sPsat",
+					NodeAttestor: "k8sPSAT",
 					//NodeAttestorEnabled: true,
 					NodeAttestorConfig: map[string]any{
 						"enabled":  true,
@@ -1574,7 +1574,7 @@ func TestSpireServerValues_GenerateValues(t *testing.T) {
 				fullnameOverride:         "spire-server",
 				logLevel:                 "DEBUG",
 				serverConfig: trustprovider.TrustProviderServerConfig{
-					NodeAttestor: "k8sPsat",
+					NodeAttestor: "k8sPSAT",
 					//NodeAttestorEnabled: true,
 					NodeAttestorConfig: map[string]any{},
 				},
@@ -1678,7 +1678,7 @@ func TestGetSDSConfig(t *testing.T) {
 			profile: "kubernetes",
 			want: map[string]any{
 				"enabled":               true,
-				"defaultSvidName":       "default",
+				"defaultSVIDName":       "default",
 				"defaultBundleName":     "ROOTCA",
 				"defaultAllBundlesName": "ALL",
 			},
@@ -1689,7 +1689,7 @@ func TestGetSDSConfig(t *testing.T) {
 			profile: "istio",
 			want: map[string]any{
 				"enabled":               true,
-				"defaultSvidName":       "default",
+				"defaultSVIDName":       "default",
 				"defaultBundleName":     "null",
 				"defaultAllBundlesName": "ROOTCA",
 			},

--- a/pkg/spire/spire_server_cli.go
+++ b/pkg/spire/spire_server_cli.go
@@ -17,7 +17,7 @@ import (
 )
 
 const (
-	k8sPsatSelectorType     = "k8s_psat"
+	k8sPSATSelectorType     = "k8s_psat"
 	agentPodNameSelector    = "agent_pod_name:"
 	k8sSelectorType         = "k8s"
 	k8sPodUIDSelectorPrefix = "pod-uid:"
@@ -94,7 +94,7 @@ func parseAgentList(output []byte) ([]Agent, error) {
 
 func getPodNameSelector(agent agentJson) string {
 	for _, selector := range agent.Selectors {
-		if selector.Type == k8sPsatSelectorType && strings.HasPrefix(selector.Value, agentPodNameSelector) {
+		if selector.Type == k8sPSATSelectorType && strings.HasPrefix(selector.Value, agentPodNameSelector) {
 			return strings.TrimPrefix(selector.Value, agentPodNameSelector)
 		}
 	}


### PR DESCRIPTION
### Summary
- This PR bumps the following Helm charts to their latest versions:
    -  `spire`
    - `spire-crds`