### PR TITLE
fix: update go to 1.24.4

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/cofide/cofidectl
 
-go 1.24.2
+go 1.24.4
 
 require (
 	buf.build/go/protoyaml v0.6.0
@@ -21,8 +21,6 @@ require (
 	gopkg.in/yaml.v3 v3.0.1
 	helm.sh/helm/v3 v3.18.3
 )
-
-require github.com/pelletier/go-toml/v2 v2.2.4 // indirect
 
 require (
 	buf.build/gen/go/bufbuild/protovalidate/protocolbuffers/go v1.36.6-20250425153114-8976f5be98c1.1 // indirect
@@ -103,6 +101,7 @@ require (
 	github.com/olekukonko/tablewriter v0.0.5
 	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/opencontainers/image-spec v1.1.1 // indirect
+	github.com/pelletier/go-toml/v2 v2.2.4 // indirect
 	github.com/peterbourgon/diskv v2.0.1+incompatible // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect


### PR DESCRIPTION
This brings fixes for:

- GO-2025-3751: Sensitive headers not cleared on cross-origin redirect
  in net/http

- GO-2025-3750: Inconsistent handling of O_CREATE|O_EXCL on Unix and
  Windows in os in syscall
