### PR TITLE
Refactor APBs and Feds to the top level config

### DIFF
--- a/internal/pkg/config/config.go
+++ b/internal/pkg/config/config.go
@@ -5,6 +5,7 @@ package config
 
 import (
 	"buf.build/go/protoyaml"
+	ap_binding_proto "github.com/cofide/cofide-api-sdk/gen/go/proto/ap_binding/v1alpha1"
 	attestation_policy_proto "github.com/cofide/cofide-api-sdk/gen/go/proto/attestation_policy/v1alpha1"
 	clusterpb "github.com/cofide/cofide-api-sdk/gen/go/proto/cluster/v1alpha1"
 	config_proto "github.com/cofide/cofide-api-sdk/gen/go/proto/config/v1alpha1"
@@ -18,6 +19,7 @@ type Config struct {
 	TrustZones          []*trust_zone_proto.TrustZone
 	Clusters            []*clusterpb.Cluster
 	AttestationPolicies []*attestation_policy_proto.AttestationPolicy
+	ApBindings          []*ap_binding_proto.APBinding
 	PluginConfig        map[string]*structpb.Struct
 	Plugins             *pluginspb.Plugins
 }
@@ -27,6 +29,7 @@ func NewConfig() *Config {
 		TrustZones:          []*trust_zone_proto.TrustZone{},
 		Clusters:            []*clusterpb.Cluster{},
 		AttestationPolicies: []*attestation_policy_proto.AttestationPolicy{},
+		ApBindings:          []*ap_binding_proto.APBinding{},
 		PluginConfig:        map[string]*structpb.Struct{},
 		Plugins:             &pluginspb.Plugins{},
 	}
@@ -41,6 +44,7 @@ func newConfigFromProto(proto *config_proto.Config) *Config {
 		TrustZones:          proto.TrustZones,
 		Clusters:            proto.Clusters,
 		AttestationPolicies: proto.AttestationPolicies,
+		ApBindings:          proto.ApBindings,
 		PluginConfig:        proto.PluginConfig,
 		Plugins:             plugins,
 	}
@@ -51,6 +55,7 @@ func (c *Config) toProto() *config_proto.Config {
 		TrustZones:          c.TrustZones,
 		Clusters:            c.Clusters,
 		AttestationPolicies: c.AttestationPolicies,
+		ApBindings:          c.ApBindings,
 		PluginConfig:        c.PluginConfig,
 		Plugins:             c.Plugins,
 	}
@@ -69,6 +74,7 @@ func unmarshalYAML(data []byte) (*Config, error) {
 		TrustZones:          []*trust_zone_proto.TrustZone{},
 		Clusters:            []*clusterpb.Cluster{},
 		AttestationPolicies: []*attestation_policy_proto.AttestationPolicy{},
+		ApBindings:          []*ap_binding_proto.APBinding{},
 		PluginConfig:        map[string]*structpb.Struct{},
 	}
 	err := protoyaml.Unmarshal(data, &proto)

--- a/internal/pkg/config/config.go
+++ b/internal/pkg/config/config.go
@@ -9,6 +9,7 @@ import (
 	attestation_policy_proto "github.com/cofide/cofide-api-sdk/gen/go/proto/attestation_policy/v1alpha1"
 	clusterpb "github.com/cofide/cofide-api-sdk/gen/go/proto/cluster/v1alpha1"
 	config_proto "github.com/cofide/cofide-api-sdk/gen/go/proto/config/v1alpha1"
+	federation_proto "github.com/cofide/cofide-api-sdk/gen/go/proto/federation/v1alpha1"
 	pluginspb "github.com/cofide/cofide-api-sdk/gen/go/proto/plugins/v1alpha1"
 	trust_zone_proto "github.com/cofide/cofide-api-sdk/gen/go/proto/trust_zone/v1alpha1"
 	"google.golang.org/protobuf/types/known/structpb"
@@ -20,6 +21,7 @@ type Config struct {
 	Clusters            []*clusterpb.Cluster
 	AttestationPolicies []*attestation_policy_proto.AttestationPolicy
 	ApBindings          []*ap_binding_proto.APBinding
+	Federations         []*federation_proto.Federation
 	PluginConfig        map[string]*structpb.Struct
 	Plugins             *pluginspb.Plugins
 }
@@ -30,6 +32,7 @@ func NewConfig() *Config {
 		Clusters:            []*clusterpb.Cluster{},
 		AttestationPolicies: []*attestation_policy_proto.AttestationPolicy{},
 		ApBindings:          []*ap_binding_proto.APBinding{},
+		Federations:         []*federation_proto.Federation{},
 		PluginConfig:        map[string]*structpb.Struct{},
 		Plugins:             &pluginspb.Plugins{},
 	}
@@ -45,6 +48,7 @@ func newConfigFromProto(proto *config_proto.Config) *Config {
 		Clusters:            proto.Clusters,
 		AttestationPolicies: proto.AttestationPolicies,
 		ApBindings:          proto.ApBindings,
+		Federations:         proto.Federations,
 		PluginConfig:        proto.PluginConfig,
 		Plugins:             plugins,
 	}
@@ -56,6 +60,7 @@ func (c *Config) toProto() *config_proto.Config {
 		Clusters:            c.Clusters,
 		AttestationPolicies: c.AttestationPolicies,
 		ApBindings:          c.ApBindings,
+		Federations:         c.Federations,
 		PluginConfig:        c.PluginConfig,
 		Plugins:             c.Plugins,
 	}
@@ -75,6 +80,7 @@ func unmarshalYAML(data []byte) (*Config, error) {
 		Clusters:            []*clusterpb.Cluster{},
 		AttestationPolicies: []*attestation_policy_proto.AttestationPolicy{},
 		ApBindings:          []*ap_binding_proto.APBinding{},
+		Federations:         []*federation_proto.Federation{},
 		PluginConfig:        map[string]*structpb.Struct{},
 	}
 	err := protoyaml.Unmarshal(data, &proto)

--- a/internal/pkg/config/config.go
+++ b/internal/pkg/config/config.go
@@ -20,7 +20,7 @@ type Config struct {
 	TrustZones          []*trust_zone_proto.TrustZone
 	Clusters            []*clusterpb.Cluster
 	AttestationPolicies []*attestation_policy_proto.AttestationPolicy
-	ApBindings          []*ap_binding_proto.APBinding
+	APBindings          []*ap_binding_proto.APBinding
 	Federations         []*federation_proto.Federation
 	PluginConfig        map[string]*structpb.Struct
 	Plugins             *pluginspb.Plugins
@@ -31,7 +31,7 @@ func NewConfig() *Config {
 		TrustZones:          []*trust_zone_proto.TrustZone{},
 		Clusters:            []*clusterpb.Cluster{},
 		AttestationPolicies: []*attestation_policy_proto.AttestationPolicy{},
-		ApBindings:          []*ap_binding_proto.APBinding{},
+		APBindings:          []*ap_binding_proto.APBinding{},
 		Federations:         []*federation_proto.Federation{},
 		PluginConfig:        map[string]*structpb.Struct{},
 		Plugins:             &pluginspb.Plugins{},
@@ -47,7 +47,7 @@ func newConfigFromProto(proto *config_proto.Config) *Config {
 		TrustZones:          proto.TrustZones,
 		Clusters:            proto.Clusters,
 		AttestationPolicies: proto.AttestationPolicies,
-		ApBindings:          proto.ApBindings,
+		APBindings:          proto.ApBindings,
 		Federations:         proto.Federations,
 		PluginConfig:        proto.PluginConfig,
 		Plugins:             plugins,
@@ -59,7 +59,7 @@ func (c *Config) toProto() *config_proto.Config {
 		TrustZones:          c.TrustZones,
 		Clusters:            c.Clusters,
 		AttestationPolicies: c.AttestationPolicies,
-		ApBindings:          c.ApBindings,
+		ApBindings:          c.APBindings,
 		Federations:         c.Federations,
 		PluginConfig:        c.PluginConfig,
 		Plugins:             c.Plugins,

--- a/internal/pkg/config/config_test.go
+++ b/internal/pkg/config/config_test.go
@@ -50,7 +50,7 @@ func TestConfig_YAMLMarshall(t *testing.T) {
 					fixtures.AttestationPolicy("ap3"),
 					fixtures.AttestationPolicy("ap4"),
 				},
-				ApBindings: []*ap_binding_proto.APBinding{
+				APBindings: []*ap_binding_proto.APBinding{
 					fixtures.APBinding("apb1"),
 					fixtures.APBinding("apb2"),
 					fixtures.APBinding("apb3"),
@@ -94,7 +94,7 @@ func TestConfig_YAMLUnmarshall(t *testing.T) {
 				TrustZones:          []*trust_zone_proto.TrustZone{},
 				Clusters:            []*clusterpb.Cluster{},
 				AttestationPolicies: []*attestation_policy_proto.AttestationPolicy{},
-				ApBindings:          []*ap_binding_proto.APBinding{},
+				APBindings:          []*ap_binding_proto.APBinding{},
 				Federations:         []*federation_proto.Federation{},
 				PluginConfig:        map[string]*structpb.Struct{},
 				Plugins:             &pluginspb.Plugins{},
@@ -119,7 +119,7 @@ func TestConfig_YAMLUnmarshall(t *testing.T) {
 					fixtures.AttestationPolicy("ap3"),
 					fixtures.AttestationPolicy("ap4"),
 				},
-				ApBindings: []*ap_binding_proto.APBinding{
+				APBindings: []*ap_binding_proto.APBinding{
 					fixtures.APBinding("apb1"),
 					fixtures.APBinding("apb2"),
 					fixtures.APBinding("apb3"),

--- a/internal/pkg/config/config_test.go
+++ b/internal/pkg/config/config_test.go
@@ -6,6 +6,7 @@ package config
 import (
 	"testing"
 
+	ap_binding_proto "github.com/cofide/cofide-api-sdk/gen/go/proto/ap_binding/v1alpha1"
 	attestation_policy_proto "github.com/cofide/cofide-api-sdk/gen/go/proto/attestation_policy/v1alpha1"
 	clusterpb "github.com/cofide/cofide-api-sdk/gen/go/proto/cluster/v1alpha1"
 	pluginspb "github.com/cofide/cofide-api-sdk/gen/go/proto/plugins/v1alpha1"
@@ -48,6 +49,11 @@ func TestConfig_YAMLMarshall(t *testing.T) {
 					fixtures.AttestationPolicy("ap3"),
 					fixtures.AttestationPolicy("ap4"),
 				},
+				ApBindings: []*ap_binding_proto.APBinding{
+					fixtures.APBinding("apb1"),
+					fixtures.APBinding("apb2"),
+					fixtures.APBinding("apb3"),
+				},
 				PluginConfig: map[string]*structpb.Struct{
 					"plugin1": fixtures.PluginConfig("plugin1"),
 					"plugin2": fixtures.PluginConfig("plugin2"),
@@ -83,6 +89,7 @@ func TestConfig_YAMLUnmarshall(t *testing.T) {
 				TrustZones:          []*trust_zone_proto.TrustZone{},
 				Clusters:            []*clusterpb.Cluster{},
 				AttestationPolicies: []*attestation_policy_proto.AttestationPolicy{},
+				ApBindings:          []*ap_binding_proto.APBinding{},
 				PluginConfig:        map[string]*structpb.Struct{},
 				Plugins:             &pluginspb.Plugins{},
 			},
@@ -105,6 +112,11 @@ func TestConfig_YAMLUnmarshall(t *testing.T) {
 					fixtures.AttestationPolicy("ap2"),
 					fixtures.AttestationPolicy("ap3"),
 					fixtures.AttestationPolicy("ap4"),
+				},
+				ApBindings: []*ap_binding_proto.APBinding{
+					fixtures.APBinding("apb1"),
+					fixtures.APBinding("apb2"),
+					fixtures.APBinding("apb3"),
 				},
 				PluginConfig: map[string]*structpb.Struct{
 					"plugin1": fixtures.PluginConfig("plugin1"),

--- a/internal/pkg/config/config_test.go
+++ b/internal/pkg/config/config_test.go
@@ -9,6 +9,7 @@ import (
 	ap_binding_proto "github.com/cofide/cofide-api-sdk/gen/go/proto/ap_binding/v1alpha1"
 	attestation_policy_proto "github.com/cofide/cofide-api-sdk/gen/go/proto/attestation_policy/v1alpha1"
 	clusterpb "github.com/cofide/cofide-api-sdk/gen/go/proto/cluster/v1alpha1"
+	federation_proto "github.com/cofide/cofide-api-sdk/gen/go/proto/federation/v1alpha1"
 	pluginspb "github.com/cofide/cofide-api-sdk/gen/go/proto/plugins/v1alpha1"
 	trust_zone_proto "github.com/cofide/cofide-api-sdk/gen/go/proto/trust_zone/v1alpha1"
 	"github.com/cofide/cofidectl/internal/pkg/test/fixtures"
@@ -54,6 +55,10 @@ func TestConfig_YAMLMarshall(t *testing.T) {
 					fixtures.APBinding("apb2"),
 					fixtures.APBinding("apb3"),
 				},
+				Federations: []*federation_proto.Federation{
+					fixtures.Federation("fed1"),
+					fixtures.Federation("fed2"),
+				},
 				PluginConfig: map[string]*structpb.Struct{
 					"plugin1": fixtures.PluginConfig("plugin1"),
 					"plugin2": fixtures.PluginConfig("plugin2"),
@@ -90,6 +95,7 @@ func TestConfig_YAMLUnmarshall(t *testing.T) {
 				Clusters:            []*clusterpb.Cluster{},
 				AttestationPolicies: []*attestation_policy_proto.AttestationPolicy{},
 				ApBindings:          []*ap_binding_proto.APBinding{},
+				Federations:         []*federation_proto.Federation{},
 				PluginConfig:        map[string]*structpb.Struct{},
 				Plugins:             &pluginspb.Plugins{},
 			},
@@ -117,6 +123,10 @@ func TestConfig_YAMLUnmarshall(t *testing.T) {
 					fixtures.APBinding("apb1"),
 					fixtures.APBinding("apb2"),
 					fixtures.APBinding("apb3"),
+				},
+				Federations: []*federation_proto.Federation{
+					fixtures.Federation("fed1"),
+					fixtures.Federation("fed2"),
 				},
 				PluginConfig: map[string]*structpb.Struct{
 					"plugin1": fixtures.PluginConfig("plugin1"),

--- a/internal/pkg/config/schema.cue
+++ b/internal/pkg/config/schema.cue
@@ -7,7 +7,6 @@
 	bundle_endpoint_url?: string
 	bundle?: #Bundle
 	federations: [...#Federation]
-	attestation_policies: [...#APBinding]
 	jwt_issuer?: string
 	bundle_endpoint_profile?: #BundleEndpointProfile
 }
@@ -125,6 +124,7 @@
 	trust_zones: [...#TrustZone]
 	clusters: [...#Cluster]
 	attestation_policies: [...#AttestationPolicy]
+	ap_bindings: [...#APBinding]
 	plugin_config?: #PluginConfig
 	plugins!: #Plugins
 }

--- a/internal/pkg/config/schema.cue
+++ b/internal/pkg/config/schema.cue
@@ -6,7 +6,6 @@
 	trust_domain!: string
 	bundle_endpoint_url?: string
 	bundle?: #Bundle
-	federations: [...#Federation]
 	jwt_issuer?: string
 	bundle_endpoint_profile?: #BundleEndpointProfile
 }
@@ -125,6 +124,7 @@
 	clusters: [...#Cluster]
 	attestation_policies: [...#AttestationPolicy]
 	ap_bindings: [...#APBinding]
+	federations: [...#Federation]
 	plugin_config?: #PluginConfig
 	plugins!: #Plugins
 }

--- a/internal/pkg/config/testdata/config/full.yaml
+++ b/internal/pkg/config/testdata/config/full.yaml
@@ -13,20 +13,12 @@ trust_zones:
               expires_at: "1738987145"
         refresh_hint: "2"
         sequence_number: "3"
-      federations:
-        - id: fed1-id
-          trust_zone_id: tz1-id
-          remote_trust_zone_id: tz2-id
       jwt_issuer: https://tz1.example.com
       bundle_endpoint_profile: BUNDLE_ENDPOINT_PROFILE_HTTPS_SPIFFE
       id: tz1-id
     - name: tz2
       trust_domain: td2
       bundle_endpoint_url: 127.0.0.2
-      federations:
-        - id: fed2-id
-          trust_zone_id: tz2-id
-          remote_trust_zone_id: tz1-id
       jwt_issuer: https://tz2.example.com
       bundle_endpoint_profile: BUNDLE_ENDPOINT_PROFILE_HTTPS_WEB
       id: tz2-id
@@ -124,6 +116,13 @@ plugin_config:
 plugins:
     data_source: fake-datasource
     provision: fake-provision
+federations:
+    - id: fed1-id
+      trust_zone_id: tz1-id
+      remote_trust_zone_id: tz2-id
+    - id: fed2-id
+      trust_zone_id: tz2-id
+      remote_trust_zone_id: tz1-id
 ap_bindings:
     - id: apb1-id
       trust_zone_id: tz1-id

--- a/internal/pkg/config/testdata/config/full.yaml
+++ b/internal/pkg/config/testdata/config/full.yaml
@@ -17,12 +17,6 @@ trust_zones:
         - id: fed1-id
           trust_zone_id: tz1-id
           remote_trust_zone_id: tz2-id
-      attestation_policies:
-        - id: apb1-id
-          trust_zone_id: tz1-id
-          policy_id: ap1-id
-          federations:
-            - trust_zone_id: tz2-id
       jwt_issuer: https://tz1.example.com
       bundle_endpoint_profile: BUNDLE_ENDPOINT_PROFILE_HTTPS_SPIFFE
       id: tz1-id
@@ -33,22 +27,12 @@ trust_zones:
         - id: fed2-id
           trust_zone_id: tz2-id
           remote_trust_zone_id: tz1-id
-      attestation_policies:
-        - id: apb2-id
-          trust_zone_id: tz2-id
-          policy_id: ap2-id
-          federations:
-            - trust_zone_id: tz1-id
       jwt_issuer: https://tz2.example.com
       bundle_endpoint_profile: BUNDLE_ENDPOINT_PROFILE_HTTPS_WEB
       id: tz2-id
     - name: tz6
       trust_domain: td6
       bundle_endpoint_url: 127.0.0.5
-      attestation_policies:
-        - id: apb3-id
-          trust_zone_id: tz6-id
-          policy_id: ap4-id
       jwt_issuer: https://tz6.example.com
       bundle_endpoint_profile: BUNDLE_ENDPOINT_PROFILE_HTTPS_WEB
       id: tz6-id
@@ -140,3 +124,17 @@ plugin_config:
 plugins:
     data_source: fake-datasource
     provision: fake-provision
+ap_bindings:
+    - id: apb1-id
+      trust_zone_id: tz1-id
+      policy_id: ap1-id
+      federations:
+        - trust_zone_id: tz2-id
+    - id: apb2-id
+      trust_zone_id: tz2-id
+      policy_id: ap2-id
+      federations:
+        - trust_zone_id: tz1-id
+    - id: apb3-id
+      trust_zone_id: tz6-id
+      policy_id: ap4-id

--- a/internal/pkg/config/testdata/config/missing_trust_zone_field.yaml
+++ b/internal/pkg/config/testdata/config/missing_trust_zone_field.yaml
@@ -4,4 +4,3 @@ trust_zones:
       federations:
         - trust_zone_id: tz1-id
           remote_trust_zone_id: tz2-id
-      attestation_policies: []

--- a/internal/pkg/config/testdata/config/missing_trust_zone_field.yaml
+++ b/internal/pkg/config/testdata/config/missing_trust_zone_field.yaml
@@ -1,6 +1,3 @@
 trust_zones:
     - trust_domain: td1
       bundle_endpoint_url: 127.0.0.1
-      federations:
-        - trust_zone_id: tz1-id
-          remote_trust_zone_id: tz2-id

--- a/internal/pkg/test/fixtures/fixtures.go
+++ b/internal/pkg/test/fixtures/fixtures.go
@@ -44,29 +44,15 @@ var trustZoneFixtures map[string]*trust_zone_proto.TrustZone = map[string]*trust
 				},
 			},
 		},
-		BundleEndpointUrl: StringPtr("127.0.0.1"),
-		Federations: []*federation_proto.Federation{
-			{
-				Id:                StringPtr("fed1-id"),
-				TrustZoneId:       StringPtr("tz1-id"),
-				RemoteTrustZoneId: StringPtr("tz2-id"),
-			},
-		},
+		BundleEndpointUrl:     StringPtr("127.0.0.1"),
 		JwtIssuer:             StringPtr("https://tz1.example.com"),
 		BundleEndpointProfile: trust_zone_proto.BundleEndpointProfile_BUNDLE_ENDPOINT_PROFILE_HTTPS_SPIFFE.Enum(),
 	},
 	"tz2": {
-		Id:                StringPtr("tz2-id"),
-		Name:              "tz2",
-		TrustDomain:       "td2",
-		BundleEndpointUrl: StringPtr("127.0.0.2"),
-		Federations: []*federation_proto.Federation{
-			{
-				Id:                StringPtr("fed2-id"),
-				TrustZoneId:       StringPtr("tz2-id"),
-				RemoteTrustZoneId: StringPtr("tz1-id"),
-			},
-		},
+		Id:                    StringPtr("tz2-id"),
+		Name:                  "tz2",
+		TrustDomain:           "td2",
+		BundleEndpointUrl:     StringPtr("127.0.0.2"),
 		JwtIssuer:             StringPtr("https://tz2.example.com"),
 		BundleEndpointProfile: trust_zone_proto.BundleEndpointProfile_BUNDLE_ENDPOINT_PROFILE_HTTPS_WEB.Enum(),
 	},
@@ -76,7 +62,6 @@ var trustZoneFixtures map[string]*trust_zone_proto.TrustZone = map[string]*trust
 		Name:                  "tz3",
 		TrustDomain:           "td3",
 		BundleEndpointUrl:     StringPtr("127.0.0.3"),
-		Federations:           []*federation_proto.Federation{},
 		BundleEndpointProfile: trust_zone_proto.BundleEndpointProfile_BUNDLE_ENDPOINT_PROFILE_HTTPS_SPIFFE.Enum(),
 	},
 	// tz4 has no federations or bound attestation policies and uses the istio profile.
@@ -85,7 +70,6 @@ var trustZoneFixtures map[string]*trust_zone_proto.TrustZone = map[string]*trust
 		Name:              "tz4",
 		TrustDomain:       "td4",
 		BundleEndpointUrl: StringPtr("127.0.0.4"),
-		Federations:       []*federation_proto.Federation{},
 	},
 	// tz5 has no federations or bound attestation policies and has an external SPIRE server.
 	"tz5": {
@@ -93,14 +77,12 @@ var trustZoneFixtures map[string]*trust_zone_proto.TrustZone = map[string]*trust
 		Name:              "tz5",
 		TrustDomain:       "td5",
 		BundleEndpointUrl: StringPtr("127.0.0.5"),
-		Federations:       []*federation_proto.Federation{},
 	},
 	"tz6": {
 		Id:                    StringPtr("tz6-id"),
 		Name:                  "tz6",
 		TrustDomain:           "td6",
 		BundleEndpointUrl:     StringPtr("127.0.0.5"),
-		Federations:           []*federation_proto.Federation{},
 		JwtIssuer:             StringPtr("https://tz6.example.com"),
 		BundleEndpointProfile: trust_zone_proto.BundleEndpointProfile_BUNDLE_ENDPOINT_PROFILE_HTTPS_WEB.Enum(),
 	},
@@ -306,6 +288,19 @@ var apBindingFixtures map[string]*ap_binding_proto.APBinding = map[string]*ap_bi
 	},
 }
 
+var federationFixtures map[string]*federation_proto.Federation = map[string]*federation_proto.Federation{
+	"fed1": {
+		Id:                StringPtr("fed1-id"),
+		TrustZoneId:       StringPtr("tz1-id"),
+		RemoteTrustZoneId: StringPtr("tz2-id"),
+	},
+	"fed2": {
+		Id:                StringPtr("fed2-id"),
+		TrustZoneId:       StringPtr("tz2-id"),
+		RemoteTrustZoneId: StringPtr("tz1-id"),
+	},
+}
+
 var pluginConfigFixtures map[string]*structpb.Struct = map[string]*structpb.Struct{
 	"plugin1": func() *structpb.Struct {
 		s, err := structpb.NewStruct(map[string]any{
@@ -394,6 +389,18 @@ func APBinding(name string) *ap_binding_proto.APBinding {
 		panic(fmt.Sprintf("failed to clone attestation policy binding: %s", err))
 	}
 	return apb
+}
+
+func Federation(name string) *federation_proto.Federation {
+	fed, ok := federationFixtures[name]
+	if !ok {
+		panic(fmt.Sprintf("invalid federation fixture %s", name))
+	}
+	fed, err := proto.CloneFederation(fed)
+	if err != nil {
+		panic(fmt.Sprintf("failed to clone federation: %s", err))
+	}
+	return fed
 }
 
 func PluginConfig(name string) *structpb.Struct {

--- a/internal/pkg/test/fixtures/fixtures.go
+++ b/internal/pkg/test/fixtures/fixtures.go
@@ -52,18 +52,6 @@ var trustZoneFixtures map[string]*trust_zone_proto.TrustZone = map[string]*trust
 				RemoteTrustZoneId: StringPtr("tz2-id"),
 			},
 		},
-		AttestationPolicies: []*ap_binding_proto.APBinding{
-			{
-				Id:          StringPtr("apb1-id"),
-				TrustZoneId: StringPtr("tz1-id"),
-				PolicyId:    StringPtr("ap1-id"),
-				Federations: []*ap_binding_proto.APBindingFederation{
-					{
-						TrustZoneId: StringPtr("tz2-id"),
-					},
-				},
-			},
-		},
 		JwtIssuer:             StringPtr("https://tz1.example.com"),
 		BundleEndpointProfile: trust_zone_proto.BundleEndpointProfile_BUNDLE_ENDPOINT_PROFILE_HTTPS_SPIFFE.Enum(),
 	},
@@ -79,18 +67,6 @@ var trustZoneFixtures map[string]*trust_zone_proto.TrustZone = map[string]*trust
 				RemoteTrustZoneId: StringPtr("tz1-id"),
 			},
 		},
-		AttestationPolicies: []*ap_binding_proto.APBinding{
-			{
-				Id:          StringPtr("apb2-id"),
-				TrustZoneId: StringPtr("tz2-id"),
-				PolicyId:    StringPtr("ap2-id"),
-				Federations: []*ap_binding_proto.APBindingFederation{
-					{
-						TrustZoneId: StringPtr("tz1-id"),
-					},
-				},
-			},
-		},
 		JwtIssuer:             StringPtr("https://tz2.example.com"),
 		BundleEndpointProfile: trust_zone_proto.BundleEndpointProfile_BUNDLE_ENDPOINT_PROFILE_HTTPS_WEB.Enum(),
 	},
@@ -101,41 +77,30 @@ var trustZoneFixtures map[string]*trust_zone_proto.TrustZone = map[string]*trust
 		TrustDomain:           "td3",
 		BundleEndpointUrl:     StringPtr("127.0.0.3"),
 		Federations:           []*federation_proto.Federation{},
-		AttestationPolicies:   []*ap_binding_proto.APBinding{},
 		BundleEndpointProfile: trust_zone_proto.BundleEndpointProfile_BUNDLE_ENDPOINT_PROFILE_HTTPS_SPIFFE.Enum(),
 	},
 	// tz4 has no federations or bound attestation policies and uses the istio profile.
 	"tz4": {
-		Id:                  StringPtr("tz4-id"),
-		Name:                "tz4",
-		TrustDomain:         "td4",
-		BundleEndpointUrl:   StringPtr("127.0.0.4"),
-		Federations:         []*federation_proto.Federation{},
-		AttestationPolicies: []*ap_binding_proto.APBinding{},
+		Id:                StringPtr("tz4-id"),
+		Name:              "tz4",
+		TrustDomain:       "td4",
+		BundleEndpointUrl: StringPtr("127.0.0.4"),
+		Federations:       []*federation_proto.Federation{},
 	},
 	// tz5 has no federations or bound attestation policies and has an external SPIRE server.
 	"tz5": {
-		Id:                  StringPtr("tz5-id"),
-		Name:                "tz5",
-		TrustDomain:         "td5",
-		BundleEndpointUrl:   StringPtr("127.0.0.5"),
-		Federations:         []*federation_proto.Federation{},
-		AttestationPolicies: []*ap_binding_proto.APBinding{},
-	},
-	"tz6": {
-		Id:                StringPtr("tz6-id"),
-		Name:              "tz6",
-		TrustDomain:       "td6",
+		Id:                StringPtr("tz5-id"),
+		Name:              "tz5",
+		TrustDomain:       "td5",
 		BundleEndpointUrl: StringPtr("127.0.0.5"),
 		Federations:       []*federation_proto.Federation{},
-		AttestationPolicies: []*ap_binding_proto.APBinding{
-			{
-				Id:          StringPtr("apb3-id"),
-				TrustZoneId: StringPtr("tz6-id"),
-				PolicyId:    StringPtr("ap4-id"),
-				Federations: []*ap_binding_proto.APBindingFederation{},
-			},
-		},
+	},
+	"tz6": {
+		Id:                    StringPtr("tz6-id"),
+		Name:                  "tz6",
+		TrustDomain:           "td6",
+		BundleEndpointUrl:     StringPtr("127.0.0.5"),
+		Federations:           []*federation_proto.Federation{},
 		JwtIssuer:             StringPtr("https://tz6.example.com"),
 		BundleEndpointProfile: trust_zone_proto.BundleEndpointProfile_BUNDLE_ENDPOINT_PROFILE_HTTPS_WEB.Enum(),
 	},
@@ -312,6 +277,35 @@ var attestationPolicyFixtures map[string]*attestation_policy_proto.AttestationPo
 	},
 }
 
+var apBindingFixtures map[string]*ap_binding_proto.APBinding = map[string]*ap_binding_proto.APBinding{
+	"apb1": {
+		Id:          StringPtr("apb1-id"),
+		TrustZoneId: StringPtr("tz1-id"),
+		PolicyId:    StringPtr("ap1-id"),
+		Federations: []*ap_binding_proto.APBindingFederation{
+			{
+				TrustZoneId: StringPtr("tz2-id"),
+			},
+		},
+	},
+	"apb2": {
+		Id:          StringPtr("apb2-id"),
+		TrustZoneId: StringPtr("tz2-id"),
+		PolicyId:    StringPtr("ap2-id"),
+		Federations: []*ap_binding_proto.APBindingFederation{
+			{
+				TrustZoneId: StringPtr("tz1-id"),
+			},
+		},
+	},
+	"apb3": {
+		Id:          StringPtr("apb3-id"),
+		TrustZoneId: StringPtr("tz6-id"),
+		PolicyId:    StringPtr("ap4-id"),
+		Federations: []*ap_binding_proto.APBindingFederation{},
+	},
+}
+
 var pluginConfigFixtures map[string]*structpb.Struct = map[string]*structpb.Struct{
 	"plugin1": func() *structpb.Struct {
 		s, err := structpb.NewStruct(map[string]any{
@@ -388,6 +382,18 @@ func AttestationPolicy(name string) *attestation_policy_proto.AttestationPolicy 
 		panic(fmt.Sprintf("failed to clone attestation policy: %s", err))
 	}
 	return ap
+}
+
+func APBinding(name string) *ap_binding_proto.APBinding {
+	apb, ok := apBindingFixtures[name]
+	if !ok {
+		panic(fmt.Sprintf("invalid attestation policy binding fixture %s", name))
+	}
+	apb, err := proto.CloneAPBinding(apb)
+	if err != nil {
+		panic(fmt.Sprintf("failed to clone attestation policy binding: %s", err))
+	}
+	return apb
 }
 
 func PluginConfig(name string) *structpb.Struct {

--- a/pkg/plugin/local/local.go
+++ b/pkg/plugin/local/local.go
@@ -116,8 +116,8 @@ func (lds *LocalDataSource) DestroyTrustZone(id string) error {
 	}
 
 	// Explicitly remove any attestation policy bindings that reference this trust zone.
-	lds.config.ApBindings = slices.DeleteFunc(
-		lds.config.ApBindings,
+	lds.config.APBindings = slices.DeleteFunc(
+		lds.config.APBindings,
 		func(apb *ap_binding_proto.APBinding) bool {
 			return apb.GetTrustZoneId() == id
 		},
@@ -399,7 +399,7 @@ func (lds *LocalDataSource) AddAttestationPolicy(policy *attestation_policy_prot
 
 func (lds *LocalDataSource) DestroyAttestationPolicy(id string) error {
 	// Fail if the policy is bound to any trust zones.
-	for _, binding := range lds.config.ApBindings {
+	for _, binding := range lds.config.APBindings {
 		if binding.GetPolicyId() == id {
 			return fmt.Errorf("attestation policy %s is bound to trust zone %s in local config", id, *binding.TrustZoneId)
 		}
@@ -470,7 +470,7 @@ func (lds *LocalDataSource) AddAPBinding(binding *ap_binding_proto.APBinding) (*
 		return nil, fmt.Errorf("failed to find attestation policy %s in local config", binding.GetPolicyId())
 	}
 
-	for _, apb := range lds.config.ApBindings {
+	for _, apb := range lds.config.APBindings {
 		if apb.GetPolicyId() == binding.GetPolicyId() && apb.GetTrustZoneId() == binding.GetTrustZoneId() {
 			return nil, fmt.Errorf("attestation policy %s is already bound to trust zone %s", binding.GetPolicyId(), binding.GetTrustZoneId())
 		}
@@ -497,7 +497,7 @@ func (lds *LocalDataSource) AddAPBinding(binding *ap_binding_proto.APBinding) (*
 		}
 	}
 
-	lds.config.ApBindings = append(lds.config.ApBindings, binding)
+	lds.config.APBindings = append(lds.config.APBindings, binding)
 	if err := lds.updateDataFile(); err != nil {
 		return nil, fmt.Errorf("failed to add attestation policy to local config: %w", err)
 	}
@@ -505,9 +505,9 @@ func (lds *LocalDataSource) AddAPBinding(binding *ap_binding_proto.APBinding) (*
 }
 
 func (lds *LocalDataSource) DestroyAPBinding(id string) error {
-	for i, tzBinding := range lds.config.ApBindings {
-		if tzBinding.GetId() == id {
-			lds.config.ApBindings = slices.Delete(lds.config.ApBindings, i, i+1)
+	for i, apBinding := range lds.config.APBindings {
+		if apBinding.GetId() == id {
+			lds.config.APBindings = slices.Delete(lds.config.APBindings, i, i+1)
 			if err := lds.updateDataFile(); err != nil {
 				return fmt.Errorf("failed to remove attestation policy binding from local config: %w", err)
 			}
@@ -527,7 +527,7 @@ func (lds *LocalDataSource) ListAPBindings(filter *datasourcepb.ListAPBindingsRe
 		}
 	}
 	bindings := []*ap_binding_proto.APBinding{}
-	for _, binding := range lds.config.ApBindings {
+	for _, binding := range lds.config.APBindings {
 		if filter != nil && filter.GetPolicyId() != "" && binding.GetPolicyId() != filter.GetPolicyId() {
 			continue
 		}

--- a/pkg/plugin/local/local.go
+++ b/pkg/plugin/local/local.go
@@ -509,7 +509,7 @@ func (lds *LocalDataSource) AddAPBinding(binding *ap_binding_proto.APBinding) (*
 func (lds *LocalDataSource) DestroyAPBinding(id string) error {
 	for i, tzBinding := range lds.config.ApBindings {
 		if tzBinding.GetId() == id {
-			lds.config.ApBindings = append(lds.config.ApBindings[:i], lds.config.ApBindings[i+1:]...)
+			lds.config.ApBindings = slices.Delete(lds.config.ApBindings, i, i+1)
 			if err := lds.updateDataFile(); err != nil {
 				return fmt.Errorf("failed to remove attestation policy binding from local config: %w", err)
 			}

--- a/pkg/plugin/local/local_test.go
+++ b/pkg/plugin/local/local_test.go
@@ -200,13 +200,13 @@ func TestLocalDataSource_DestroyTrustZone(t *testing.T) {
 				assert.Len(t, lds.config.TrustZones, 1)
 				// nolint:staticcheck
 				assert.Len(t, lds.config.TrustZones[0].Federations, 0)
-				// Check that the association policy binding was removed too.
+				// Check that the attestation policy binding was removed too.
 				assert.Len(t, lds.config.ApBindings, 1) // Check that the trust zone removal was persisted.
 				gotConfig := readConfig(t, loader)
 				assert.Len(t, gotConfig.TrustZones, 1)
 				// nolint:staticcheck
 				assert.Len(t, gotConfig.TrustZones[0].Federations, 0)
-				// Check that the association policy binding was removed too.
+				// Check that the attestation policy binding was removed too.
 				assert.Len(t, gotConfig.ApBindings, 1)
 			}
 		})

--- a/pkg/plugin/local/local_test.go
+++ b/pkg/plugin/local/local_test.go
@@ -183,6 +183,10 @@ func TestLocalDataSource_DestroyTrustZone(t *testing.T) {
 					fixtures.AttestationPolicy("ap1"),
 					fixtures.AttestationPolicy("ap2"),
 				},
+				ApBindings: []*ap_binding_proto.APBinding{
+					fixtures.APBinding("apb1"),
+					fixtures.APBinding("apb2"),
+				},
 				Plugins: fixtures.Plugins("plugins1"),
 			}
 			lds, loader := buildLocalDataSource(t, cfg)
@@ -196,11 +200,14 @@ func TestLocalDataSource_DestroyTrustZone(t *testing.T) {
 				assert.Len(t, lds.config.TrustZones, 1)
 				// nolint:staticcheck
 				assert.Len(t, lds.config.TrustZones[0].Federations, 0)
-				// Check that the trust zone removal was persisted.
+				// Check that the association policy binding was removed too.
+				assert.Len(t, lds.config.ApBindings, 1) // Check that the trust zone removal was persisted.
 				gotConfig := readConfig(t, loader)
 				assert.Len(t, gotConfig.TrustZones, 1)
 				// nolint:staticcheck
 				assert.Len(t, gotConfig.TrustZones[0].Federations, 0)
+				// Check that the association policy binding was removed too.
+				assert.Len(t, gotConfig.ApBindings, 1)
 			}
 		})
 	}

--- a/pkg/plugin/local/local_test.go
+++ b/pkg/plugin/local/local_test.go
@@ -59,7 +59,7 @@ func TestNewLocalDataSource(t *testing.T) {
 				TrustZones:          []*trust_zone_proto.TrustZone{},
 				Clusters:            []*clusterpb.Cluster{},
 				AttestationPolicies: []*attestation_policy_proto.AttestationPolicy{},
-				ApBindings:          []*ap_binding_proto.APBinding{},
+				APBindings:          []*ap_binding_proto.APBinding{},
 				Federations:         []*federation_proto.Federation{},
 				PluginConfig:        map[string]*structpb.Struct{},
 				Plugins:             fixtures.Plugins("plugins1"),
@@ -184,7 +184,7 @@ func TestLocalDataSource_DestroyTrustZone(t *testing.T) {
 					fixtures.AttestationPolicy("ap1"),
 					fixtures.AttestationPolicy("ap2"),
 				},
-				ApBindings: []*ap_binding_proto.APBinding{
+				APBindings: []*ap_binding_proto.APBinding{
 					fixtures.APBinding("apb1"),
 					fixtures.APBinding("apb2"),
 				},
@@ -206,14 +206,14 @@ func TestLocalDataSource_DestroyTrustZone(t *testing.T) {
 				// Check that the federations were removed too.
 				assert.Len(t, lds.config.Federations, 0)
 				// Check that the attestation policy binding was removed too.
-				assert.Len(t, lds.config.ApBindings, 1)
+				assert.Len(t, lds.config.APBindings, 1)
 
 				// Check that the trust zone removal was persisted.
 				gotConfig := readConfig(t, loader)
 				assert.Len(t, gotConfig.TrustZones, 1)
 				assert.Len(t, gotConfig.Federations, 0)
 				// Check that the attestation policy binding was removed too.
-				assert.Len(t, gotConfig.ApBindings, 1)
+				assert.Len(t, gotConfig.APBindings, 1)
 			}
 		})
 	}
@@ -874,7 +874,7 @@ func TestLocalDataSource_DestroyAttestationPolicy(t *testing.T) {
 					fixtures.AttestationPolicy("ap1"),
 					fixtures.AttestationPolicy("ap2"),
 				},
-				ApBindings: []*ap_binding_proto.APBinding{
+				APBindings: []*ap_binding_proto.APBinding{
 					fixtures.APBinding("apb2"),
 				},
 				Plugins: fixtures.Plugins("plugins1"),
@@ -1112,7 +1112,7 @@ func TestLocalDataSource_AddAPBinding(t *testing.T) {
 					fixtures.AttestationPolicy("ap1"),
 					fixtures.AttestationPolicy("ap2"),
 				},
-				ApBindings: []*ap_binding_proto.APBinding{
+				APBindings: []*ap_binding_proto.APBinding{
 					fixtures.APBinding("apb1"),
 					fixtures.APBinding("apb2"),
 				},
@@ -1133,11 +1133,11 @@ func TestLocalDataSource_AddAPBinding(t *testing.T) {
 				require.Nil(t, err)
 				tt.binding.Id = got.Id
 				assert.EqualExportedValues(t, tt.binding, got)
-				assert.False(t, slices.Contains(lds.config.ApBindings, tt.binding), "Pointer to attestation policy binding stored in config")
-				assert.False(t, slices.Contains(lds.config.ApBindings, got), "Pointer to attestation policy binding in config returned")
+				assert.False(t, slices.Contains(lds.config.APBindings, tt.binding), "Pointer to attestation policy binding stored in config")
+				assert.False(t, slices.Contains(lds.config.APBindings, got), "Pointer to attestation policy binding in config returned")
 				// Check that the binding was persisted.
 				gotConfig := readConfig(t, loader)
-				gotBinding := gotConfig.ApBindings[2]
+				gotBinding := gotConfig.APBindings[2]
 				assert.EqualExportedValues(t, tt.binding, gotBinding)
 				assert.NotNil(t, gotBinding.Id)
 			}
@@ -1174,7 +1174,7 @@ func TestLocalDataSource_DestroyAPBinding(t *testing.T) {
 				AttestationPolicies: []*attestation_policy_proto.AttestationPolicy{
 					fixtures.AttestationPolicy("ap1"),
 				},
-				ApBindings: []*ap_binding_proto.APBinding{
+				APBindings: []*ap_binding_proto.APBinding{
 					fixtures.APBinding("apb1"),
 				},
 				Plugins: fixtures.Plugins("plugins1"),
@@ -1186,13 +1186,13 @@ func TestLocalDataSource_DestroyAPBinding(t *testing.T) {
 				assert.EqualError(t, err, tt.wantErrString)
 			} else {
 				require.Nil(t, err)
-				for _, binding := range lds.config.ApBindings {
+				for _, binding := range lds.config.APBindings {
 					assert.NotEqual(t, tt.bindingID, binding.Id)
 				}
 
 				// Check that the binding removal was persisted.
 				gotConfig := readConfig(t, loader)
-				for _, binding := range gotConfig.ApBindings {
+				for _, binding := range gotConfig.APBindings {
 					assert.NotEqual(t, tt.bindingID, binding.Id)
 				}
 			}
@@ -1276,7 +1276,7 @@ func TestLocalDataSource_ListAPBindings(t *testing.T) {
 				AttestationPolicies: []*attestation_policy_proto.AttestationPolicy{
 					fixtures.AttestationPolicy("ap1"),
 				},
-				ApBindings: []*ap_binding_proto.APBinding{
+				APBindings: []*ap_binding_proto.APBinding{
 					fixtures.APBinding("apb1"),
 				},
 				Plugins: fixtures.Plugins("plugins1"),
@@ -1290,7 +1290,7 @@ func TestLocalDataSource_ListAPBindings(t *testing.T) {
 				require.NoError(t, err)
 				assert.EqualExportedValues(t, tt.want, got)
 				for _, gotBinding := range got {
-					assert.False(t, slices.Contains(lds.config.ApBindings, gotBinding), "Pointer to attestation policy binding in config returned")
+					assert.False(t, slices.Contains(lds.config.APBindings, gotBinding), "Pointer to attestation policy binding in config returned")
 				}
 			}
 		})

--- a/pkg/provider/helm/values_test.go
+++ b/pkg/provider/helm/values_test.go
@@ -9,6 +9,7 @@ import (
 	ap_binding_proto "github.com/cofide/cofide-api-sdk/gen/go/proto/ap_binding/v1alpha1"
 	attestation_policy_proto "github.com/cofide/cofide-api-sdk/gen/go/proto/attestation_policy/v1alpha1"
 	clusterpb "github.com/cofide/cofide-api-sdk/gen/go/proto/cluster/v1alpha1"
+	federation_proto "github.com/cofide/cofide-api-sdk/gen/go/proto/federation/v1alpha1"
 	trust_zone_proto "github.com/cofide/cofide-api-sdk/gen/go/proto/trust_zone/v1alpha1"
 	"github.com/cofide/cofidectl/internal/pkg/config"
 	"github.com/cofide/cofidectl/internal/pkg/test/fixtures"
@@ -44,11 +45,8 @@ func TestHelmValuesGenerator_GenerateValues_success(t *testing.T) {
 				return cluster
 			}(),
 			configFunc: func(cfg *config.Config) {
-				trustZone, ok := cfg.GetTrustZoneByID("tz1-id")
-				require.True(t, ok)
 				cfg.ApBindings = cfg.ApBindings[1:]
-				// nolint:staticcheck
-				trustZone.Federations = nil
+				cfg.Federations = nil
 			},
 			want: Values{
 				"global": Values{
@@ -564,11 +562,8 @@ func TestHelmValuesGenerator_GenerateValues_AdditionalValues(t *testing.T) {
 				return cluster
 			}(),
 			configFunc: func(cfg *config.Config) {
-				trustZone, ok := cfg.GetTrustZoneByID("tz1-id")
-				require.True(t, ok)
 				cfg.ApBindings = cfg.ApBindings[1:]
-				// nolint:staticcheck
-				trustZone.Federations = nil
+				cfg.Federations = nil
 			},
 			values: Values{
 				"spire-server": Values{
@@ -828,10 +823,7 @@ func TestHelmValuesGenerator_GenerateValues_failure(t *testing.T) {
 			trustZone: fixtures.TrustZone("tz1"),
 			cluster:   fixtures.Cluster("local1"),
 			configFunc: func(cfg *config.Config) {
-				trustZone, ok := cfg.GetTrustZoneByID("tz1-id")
-				require.True(t, ok)
-				// nolint:staticcheck
-				trustZone.Federations[0].RemoteTrustZoneId = fixtures.StringPtr("invalid-tz")
+				cfg.Federations[0].RemoteTrustZoneId = fixtures.StringPtr("invalid-tz")
 			},
 			wantErrString: "failed to find trust zone invalid-tz in local config",
 		},
@@ -1836,6 +1828,10 @@ func defaultConfig() *config.Config {
 			fixtures.APBinding("apb1"),
 			fixtures.APBinding("apb2"),
 			fixtures.APBinding("apb3"),
+		},
+		Federations: []*federation_proto.Federation{
+			fixtures.Federation("fed1"),
+			fixtures.Federation("fed2"),
 		},
 		Plugins: fixtures.Plugins("plugins1"),
 	}

--- a/pkg/provider/helm/values_test.go
+++ b/pkg/provider/helm/values_test.go
@@ -45,7 +45,7 @@ func TestHelmValuesGenerator_GenerateValues_success(t *testing.T) {
 				return cluster
 			}(),
 			configFunc: func(cfg *config.Config) {
-				cfg.ApBindings = cfg.ApBindings[1:]
+				cfg.APBindings = cfg.APBindings[1:]
 				cfg.Federations = nil
 			},
 			want: Values{
@@ -562,7 +562,7 @@ func TestHelmValuesGenerator_GenerateValues_AdditionalValues(t *testing.T) {
 				return cluster
 			}(),
 			configFunc: func(cfg *config.Config) {
-				cfg.ApBindings = cfg.ApBindings[1:]
+				cfg.APBindings = cfg.APBindings[1:]
 				cfg.Federations = nil
 			},
 			values: Values{
@@ -814,7 +814,7 @@ func TestHelmValuesGenerator_GenerateValues_failure(t *testing.T) {
 			trustZone: fixtures.TrustZone("tz1"),
 			cluster:   fixtures.Cluster("local1"),
 			configFunc: func(cfg *config.Config) {
-				cfg.ApBindings[0].PolicyId = fixtures.StringPtr("invalid-ap")
+				cfg.APBindings[0].PolicyId = fixtures.StringPtr("invalid-ap")
 			},
 			wantErrString: "failed to find attestation policy invalid-ap in local config",
 		},
@@ -1824,7 +1824,7 @@ func defaultConfig() *config.Config {
 			fixtures.AttestationPolicy("ap2"),
 			fixtures.AttestationPolicy("ap4"),
 		},
-		ApBindings: []*ap_binding_proto.APBinding{
+		APBindings: []*ap_binding_proto.APBinding{
 			fixtures.APBinding("apb1"),
 			fixtures.APBinding("apb2"),
 			fixtures.APBinding("apb3"),

--- a/pkg/provider/helm/values_test.go
+++ b/pkg/provider/helm/values_test.go
@@ -6,6 +6,7 @@ package helm
 import (
 	"testing"
 
+	ap_binding_proto "github.com/cofide/cofide-api-sdk/gen/go/proto/ap_binding/v1alpha1"
 	attestation_policy_proto "github.com/cofide/cofide-api-sdk/gen/go/proto/attestation_policy/v1alpha1"
 	clusterpb "github.com/cofide/cofide-api-sdk/gen/go/proto/cluster/v1alpha1"
 	trust_zone_proto "github.com/cofide/cofide-api-sdk/gen/go/proto/trust_zone/v1alpha1"
@@ -45,8 +46,7 @@ func TestHelmValuesGenerator_GenerateValues_success(t *testing.T) {
 			configFunc: func(cfg *config.Config) {
 				trustZone, ok := cfg.GetTrustZoneByID("tz1-id")
 				require.True(t, ok)
-				// nolint:staticcheck
-				trustZone.AttestationPolicies = nil
+				cfg.ApBindings = cfg.ApBindings[1:]
 				// nolint:staticcheck
 				trustZone.Federations = nil
 			},
@@ -566,8 +566,7 @@ func TestHelmValuesGenerator_GenerateValues_AdditionalValues(t *testing.T) {
 			configFunc: func(cfg *config.Config) {
 				trustZone, ok := cfg.GetTrustZoneByID("tz1-id")
 				require.True(t, ok)
-				// nolint:staticcheck
-				trustZone.AttestationPolicies = nil
+				cfg.ApBindings = cfg.ApBindings[1:]
 				// nolint:staticcheck
 				trustZone.Federations = nil
 			},
@@ -820,10 +819,7 @@ func TestHelmValuesGenerator_GenerateValues_failure(t *testing.T) {
 			trustZone: fixtures.TrustZone("tz1"),
 			cluster:   fixtures.Cluster("local1"),
 			configFunc: func(cfg *config.Config) {
-				trustZone, ok := cfg.GetTrustZoneByName("tz1")
-				require.True(t, ok)
-				// nolint:staticcheck
-				trustZone.AttestationPolicies[0].PolicyId = fixtures.StringPtr("invalid-ap")
+				cfg.ApBindings[0].PolicyId = fixtures.StringPtr("invalid-ap")
 			},
 			wantErrString: "failed to find attestation policy invalid-ap in local config",
 		},
@@ -1835,6 +1831,11 @@ func defaultConfig() *config.Config {
 			fixtures.AttestationPolicy("ap1"),
 			fixtures.AttestationPolicy("ap2"),
 			fixtures.AttestationPolicy("ap4"),
+		},
+		ApBindings: []*ap_binding_proto.APBinding{
+			fixtures.APBinding("apb1"),
+			fixtures.APBinding("apb2"),
+			fixtures.APBinding("apb3"),
 		},
 		Plugins: fixtures.Plugins("plugins1"),
 	}


### PR DESCRIPTION
Refactors APBs (attestation policy bindings) and Feds (federations) from being nested in trust zones (deprecated) to top-level config (the new way).

Fixes issue #175.