### PR TITLE
fix: don't try to uninstall SPIRE CRDs if they were not installed

### DIFF
--- a/pkg/provider/helm/helm.go
+++ b/pkg/provider/helm/helm.go
@@ -310,18 +310,20 @@ func (h *HelmSPIREProvider) ExecuteUpgrade(statusCh chan<- *provisionpb.Status) 
 // The action is performed synchronously and status is streamed through the provided status channel.
 func (h *HelmSPIREProvider) ExecuteUninstall(statusCh chan<- *provisionpb.Status) error {
 	sb := provision.NewStatusBuilder(h.trustZoneName, h.cluster.GetName())
-	statusCh <- sb.Ok("Uninstalling", "Uninstalling SPIRE CRDs")
-	_, err := h.uninstallSPIRECRDs()
-	if err != nil {
-		statusCh <- sb.Error("Uninstalling", "Failed to uninstall SPIRE CRDs", err)
-		return err
-	}
-
 	statusCh <- sb.Ok("Uninstalling", "Uninstalling SPIRE chart")
-	_, err = h.uninstallSPIRE()
+	_, err := h.uninstallSPIRE()
 	if err != nil {
 		statusCh <- sb.Error("Uninstalling", "Failed to uninstall SPIRE chart", err)
 		return err
+	}
+
+	if h.installCRDs {
+		statusCh <- sb.Ok("Uninstalling", "Uninstalling SPIRE CRDs")
+		_, err := h.uninstallSPIRECRDs()
+		if err != nil {
+			statusCh <- sb.Error("Uninstalling", "Failed to uninstall SPIRE CRDs", err)
+			return err
+		}
 	}
 
 	statusCh <- sb.Done("Uninstalled", "Uninstallation completed")

--- a/tests/integration/single-trust-zone/test.sh
+++ b/tests/integration/single-trust-zone/test.sh
@@ -162,6 +162,10 @@ function main() {
   run_tests
   show_workload_status
   check_overridden_values
+  # Check for idempotence of up
+  up
+  down
+  # Check for idempotence of down
   down
   delete
   check_delete


### PR DESCRIPTION
Otherwise we may hit the following issue:

  Uninstalling: Failed to uninstall SPIRE CRDs for workload-63d89cf2 in 63d89cf2
  Error: spire-crds not installed
