### PR TITLE
fix: bump go to 1.24.6

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/cofide/cofidectl
 
-go 1.24.4
+go 1.24.6
 
 require (
 	buf.build/go/protoyaml v0.6.0


### PR DESCRIPTION
Fixes https://pkg.go.dev/vuln/GO-2025-3849
