### PR TITLE
Parse the OIDC issuer URL and handle errors

### DIFF
--- a/cmd/cofidectl/cmd/trustzone/trustzone.go
+++ b/cmd/cofidectl/cmd/trustzone/trustzone.go
@@ -581,6 +581,14 @@ func validateOIDCIssuerURL(oidcIssuerURL string) (string, error) {
 		return "", fmt.Errorf("URL must include a host")
 	}
 
+	if u.RawQuery != "" {
+		return "", fmt.Errorf("URL must not have a query component")
+	}
+
+	if u.Fragment != "" {
+		return "", fmt.Errorf("URL must not have a fragment component")
+	}
+
 	// Normalize by removing any trailing slash.
-	return strings.TrimSuffix(oidcIssuerURL, "/"), nil
+	return strings.TrimRight(oidcIssuerURL, "/"), nil
 }

--- a/cmd/cofidectl/cmd/trustzone/trustzone.go
+++ b/cmd/cofidectl/cmd/trustzone/trustzone.go
@@ -12,6 +12,7 @@ import (
 	"os"
 	"slices"
 	"strconv"
+	"strings"
 
 	clusterpb "github.com/cofide/cofide-api-sdk/gen/go/proto/cluster/v1alpha1"
 	datasourcepb "github.com/cofide/cofide-api-sdk/gen/go/proto/cofidectl/datasource_plugin/v1alpha2"
@@ -589,5 +590,6 @@ func validateAndParseOIDCIssuerURL(oidcIssuerURL string) (string, error) {
 		return "", fmt.Errorf("URL must not have a fragment component")
 	}
 
+	u.Path = strings.TrimRight(u.Path, "/")
 	return u.String(), nil
 }

--- a/cmd/cofidectl/cmd/trustzone/trustzone.go
+++ b/cmd/cofidectl/cmd/trustzone/trustzone.go
@@ -12,7 +12,6 @@ import (
 	"os"
 	"slices"
 	"strconv"
-	"strings"
 
 	clusterpb "github.com/cofide/cofide-api-sdk/gen/go/proto/cluster/v1alpha1"
 	datasourcepb "github.com/cofide/cofide-api-sdk/gen/go/proto/cofidectl/datasource_plugin/v1alpha2"
@@ -553,7 +552,8 @@ func validateOpts(opts addOpts) error {
 	if err != nil {
 		return err
 	}
-	normalisedURL, err := validateOIDCIssuerURL(opts.kubernetesClusterOIDCIssuerURL)
+
+	normalisedURL, err := validateAndParseOIDCIssuerURL(opts.kubernetesClusterOIDCIssuerURL)
 	if err != nil {
 		return fmt.Errorf("invalid --kubernetes-oidc-issuer: %w", err)
 	}
@@ -562,7 +562,7 @@ func validateOpts(opts addOpts) error {
 	return nil
 }
 
-func validateOIDCIssuerURL(oidcIssuerURL string) (string, error) {
+func validateAndParseOIDCIssuerURL(oidcIssuerURL string) (string, error) {
 	// It's an optional flag, so if it's empty, it's valid.
 	if oidcIssuerURL == "" {
 		return "", nil
@@ -589,6 +589,5 @@ func validateOIDCIssuerURL(oidcIssuerURL string) (string, error) {
 		return "", fmt.Errorf("URL must not have a fragment component")
 	}
 
-	// Normalize by removing any trailing slash.
-	return strings.TrimRight(oidcIssuerURL, "/"), nil
+	return u.String(), nil
 }

--- a/cmd/cofidectl/cmd/trustzone/trustzone_test.go
+++ b/cmd/cofidectl/cmd/trustzone/trustzone_test.go
@@ -53,6 +53,7 @@ func TestValidateOpts(t *testing.T) {
 		{domain: "valid.com", oidcIssuerURL: "https://validwithport.oidc:644", errExpected: false},
 		{domain: "valid.com", oidcIssuerURL: "h://invalid.oidc", errExpected: true},
 		{domain: "INVALID.COM", oidcIssuerURL: "https://valid.oidc", errExpected: true},
+		{domain: "INVALID.COM", oidcIssuerURL: "http://valid.oidc", errExpected: true},
 	}
 
 	for _, tc := range tt {

--- a/cmd/cofidectl/cmd/trustzone/trustzone_test.go
+++ b/cmd/cofidectl/cmd/trustzone/trustzone_test.go
@@ -53,7 +53,8 @@ func TestValidateOpts(t *testing.T) {
 		{domain: "valid.com", oidcIssuerURL: "https://validwithport.oidc:644", errExpected: false},
 		{domain: "valid.com", oidcIssuerURL: "h://invalid.oidc", errExpected: true},
 		{domain: "INVALID.COM", oidcIssuerURL: "https://valid.oidc", errExpected: true},
-		{domain: "INVALID.COM", oidcIssuerURL: "http://valid.oidc", errExpected: true},
+		{domain: "valid.com", oidcIssuerURL: "http://valid.oidc", errExpected: true},
+		{domain: "valid.com", oidcIssuerURL: "https://valid.oidc/", errExpected: false},
 	}
 
 	for _, tc := range tt {


### PR DESCRIPTION
This PR improves the error handling in parsing the OIDC issuer URL. The OIDC issuer URL should be served over HTTPS. It  also removes any trailing slashes if present.