### PR TITLE
chore: Skip Helm repo add when `HELM_REPO_PATH` is defined

### DIFF
--- a/pkg/plugin/provision/spirehelm/spirehelm.go
+++ b/pkg/plugin/provision/spirehelm/spirehelm.go
@@ -98,10 +98,10 @@ func (h *SpireHelm) deploy(ctx context.Context, ds datasource.DataSource, opts *
 	}
 
 	if repo, ok := os.LookupEnv("HELM_REPO_PATH"); ok && repo != "" {
-		statusCh <- provision.StatusOk("Deploying", fmt.Sprintf("Found HELM_REPO_PATH value, using local chart: %s", repo))
+		statusCh <- provision.StatusOk("Preparing", fmt.Sprintf("Found HELM_REPO_PATH value, using local chart: %s", repo))
 	} else if err := h.AddSPIRERepository(ctx, opts.KubeCfgFile, statusCh); err != nil {
-			return err
-  }
+		return err
+	}
 
 	if err := h.InstallSPIREStack(ctx, ds, trustZoneClusters, opts.KubeCfgFile, statusCh); err != nil {
 		return err

--- a/pkg/plugin/provision/spirehelm/spirehelm_test.go
+++ b/pkg/plugin/provision/spirehelm/spirehelm_test.go
@@ -139,7 +139,7 @@ func TestSpireHelm_Deploy_with_env_HELM_REPO_PATH(t *testing.T) {
 
 	statuses := collectStatuses(statusCh)
 	want := []*provisionpb.Status{
-		provision.StatusOk("Deploying", fmt.Sprintf("Found HELM_REPO_PATH value, using local chart: %s", dummyPath)),
+		provision.StatusOk("Preparing", fmt.Sprintf("Found HELM_REPO_PATH value, using local chart: %s", dummyPath)),
 		provision.StatusOk("Installing", "Installing SPIRE CRDs for local2 in tz2"),
 		provision.StatusOk("Installing", "Installing SPIRE chart for local2 in tz2"),
 		provision.StatusDone("Installed", "Installation completed for local2 in tz2"),


### PR DESCRIPTION
`cofidectl` accepts the environment variable `HELM_REPO_PATH` to use a local Helm chart to install the SPIRE charts. At present, the CLI will still explicitly add the remote chart repository when this is set even though it is not used.

Skipping this step is useful for scenarios where the CLI may not have network connectivity, but has all the requisite charts and images locally