### PR TITLE
chore: bump Go to 1.24.11

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/cofide/cofidectl
 
-go 1.24.9
+go 1.24.11
 
 require (
 	buf.build/go/protoyaml v0.6.0


### PR DESCRIPTION
Addresses the following vulnerabilities:

* https://pkg.go.dev/vuln/GO-2025-4155
* https://pkg.go.dev/vuln/GO-2025-4175
