### PR TITLE
chore: bump to go 1.25.5

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/cofide/cofidectl
 
-go 1.25.0
+go 1.25.5
 
 require (
 	buf.build/go/protoyaml v0.6.0


### PR DESCRIPTION
The dependabot update for the k8s group bumped it to 1.25.0, which
includes several vulnerabilities.
