### PR TITLE
feat: allow loading custom in-process plugins

### DIFF
--- a/cmd/cofidectl-test-plugin/main.go
+++ b/cmd/cofidectl-test-plugin/main.go
@@ -33,7 +33,7 @@ func main() {
 }
 
 func run() error {
-	cmdCtx := cmdcontext.NewCommandContext(cofideConfigFile)
+	cmdCtx := cmdcontext.NewCommandContext(cofideConfigFile, nil)
 	defer cmdCtx.Shutdown()
 	go cmdCtx.HandleSignals()
 

--- a/cmd/cofidectl/main.go
+++ b/cmd/cofidectl/main.go
@@ -35,7 +35,7 @@ func main() {
 }
 
 func run() error {
-	cmdCtx := cmdcontext.NewCommandContext(cofideConfigFile)
+	cmdCtx := cmdcontext.NewCommandContext(cofideConfigFile, nil)
 	defer cmdCtx.Shutdown()
 	go cmdCtx.HandleSignals()
 

--- a/pkg/cmd/context/context.go
+++ b/pkg/cmd/context/context.go
@@ -27,14 +27,15 @@ type CommandContext struct {
 }
 
 // NewCommandContext returns a command context wired up with a config loader and plugin manager.
-func NewCommandContext(cofideConfigFile string) *CommandContext {
+// If customLoader is non-nil, it may be used to load custom in-process plugins.
+func NewCommandContext(cofideConfigFile string, customLoader manager.PluginLoader) *CommandContext {
 	logLevel := &slog.LevelVar{}
 	handler := slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: logLevel})
 	logger := slog.New(handler)
 	slog.SetDefault(logger)
 	ctx, cancel := context.WithCancelCause(context.Background())
 	configLoader := config.NewFileLoader(cofideConfigFile)
-	pluginManager := manager.NewManager(configLoader)
+	pluginManager := manager.NewManager(configLoader, customLoader)
 	return &CommandContext{Ctx: ctx, cancel: cancel, PluginManager: pluginManager, logLevel: logLevel}
 }
 


### PR DESCRIPTION
Previously only the built-in local and spire-helm plugins could be
loaded in-process. Other plugins needed to be loaded as external
(go-plugin) plugins. This change makes it possible to customise the
loading of in-process plugins by passing a PluginLoader to the
CommandContext.
