### PR TITLE
chore: update to Go 1.25.6

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/cofide/cofidectl
 
-go 1.25.5
+go 1.25.6
 
 require (
 	buf.build/go/protoyaml v0.6.0


### PR DESCRIPTION
Memory exhaustion in query parameter parsing in net/url
https://pkg.go.dev/vuln/GO-2026-4341

Handshake messages may be processed at the incorrect encryption level in
crypto/tls
https://pkg.go.dev/vuln/GO-2026-4340
