### PR TITLE
Separate cluster creation and trust zone creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,8 @@ Deploying to a Kubernetes cluster is as simple as a few commands. This example a
 ```sh
 rm -f cofide.yaml
 ./cofidectl init
-./cofidectl trust-zone add cofide-a --trust-domain cofide-a.test --kubernetes-cluster kind --profile kubernetes --kubernetes-context kind-kind
+./cofidectl trust-zone add cofide-a --trust-domain cofide-a.test
+./cofidectl cluster add kind --trust-zone cofide-a --profile kubernetes --kubernetes-context kind-kind
 ```
 
 Next up is to add an 'attestation policy' - these are `cofidectl` rules which are used to describe the properties of a workload and it's environment to determine workload identity issuance. In this example, we will create a policy (`namespace-demo`) that will enable SPIFFE identities for workloads in the `demo` namespace.

--- a/cmd/cofidectl/cmd/trustzone/trustzone.go
+++ b/cmd/cofidectl/cmd/trustzone/trustzone.go
@@ -8,21 +8,14 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
-	"net/url"
 	"os"
-	"slices"
 	"strconv"
-	"strings"
 
-	clusterpb "github.com/cofide/cofide-api-sdk/gen/go/proto/cluster/v1alpha1"
 	datasourcepb "github.com/cofide/cofide-api-sdk/gen/go/proto/cofidectl/datasource_plugin/v1alpha2"
 	"github.com/cofide/cofidectl/cmd/cofidectl/cmd/trustzone/helm"
-	trustprovider "github.com/cofide/cofidectl/internal/pkg/trustprovider"
 	"github.com/cofide/cofidectl/internal/pkg/trustzone"
 	cmdcontext "github.com/cofide/cofidectl/pkg/cmd/context"
-	"github.com/manifoldco/promptui"
 
-	trust_provider_proto "github.com/cofide/cofide-api-sdk/gen/go/proto/trust_provider/v1alpha1"
 	trust_zone_proto "github.com/cofide/cofide-api-sdk/gen/go/proto/trust_zone/v1alpha1"
 	"github.com/cofide/cofidectl/cmd/cofidectl/cmd/renderer"
 	kubeutil "github.com/cofide/cofidectl/pkg/kube"
@@ -126,16 +119,10 @@ This command will add a new trust zone to the Cofide configuration state.
 `
 
 type addOpts struct {
-	name                           string
-	trustDomain                    string
-	kubernetesCluster              string
-	kubernetesClusterOIDCIssuerURL string
-	kubernetesClusterCACert        string
-	context                        string
-	profile                        string
-	jwtIssuer                      string
-	externalServer                 bool
-	noCluster                      bool
+	name           string
+	trustDomain    string
+	jwtIssuer      string
+	externalServer bool
 }
 
 func (c *TrustZoneCommand) GetAddCommand() *cobra.Command {
@@ -153,17 +140,6 @@ func (c *TrustZoneCommand) GetAddCommand() *cobra.Command {
 			return nil
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if !opts.noCluster {
-				if opts.kubernetesCluster == "" {
-					return errors.New("required flag(s) \"kubernetes-cluster\" not set")
-				}
-
-				err := c.getKubernetesContext(cmd, &opts)
-				if err != nil {
-					return err
-				}
-			}
-
 			ds, err := c.cmdCtx.PluginManager.GetDataSource(cmd.Context())
 			if err != nil {
 				return err
@@ -174,14 +150,8 @@ func (c *TrustZoneCommand) GetAddCommand() *cobra.Command {
 
 	f := cmd.Flags()
 	f.StringVar(&opts.trustDomain, "trust-domain", "", "Trust domain to use for this trust zone")
-	f.StringVar(&opts.kubernetesCluster, "kubernetes-cluster", "", "Kubernetes cluster associated with this trust zone")
-	f.StringVar(&opts.kubernetesClusterOIDCIssuerURL, "kubernetes-oidc-issuer", "", "OIDC issuer URL for the Kubernetes cluster")
-	f.StringVar(&opts.kubernetesClusterCACert, "kubernetes-ca-cert", "", "Path to the CA certificate of the Kubernetes cluster, used for TLS during OIDC validation")
-	f.StringVar(&opts.context, "kubernetes-context", "", "Kubernetes context to use for this trust zone")
-	f.StringVar(&opts.profile, "profile", "kubernetes", "Cofide profile used in the installation (e.g. kubernetes, istio)")
 	f.StringVar(&opts.jwtIssuer, "jwt-issuer", "", "JWT issuer to use for this trust zone")
 	f.BoolVar(&opts.externalServer, "external-server", false, "If the SPIRE server runs externally")
-	f.BoolVar(&opts.noCluster, "no-cluster", false, "Create a trust zone without an associated cluster")
 
 	cobra.CheckErr(cmd.MarkFlagRequired("trust-domain"))
 
@@ -189,15 +159,6 @@ func (c *TrustZoneCommand) GetAddCommand() *cobra.Command {
 }
 
 func (c *TrustZoneCommand) addTrustZone(ctx context.Context, opts addOpts, ds datasource.DataSource) error {
-	var trustProviderKind string
-	var err error
-	if !opts.noCluster {
-		trustProviderKind, err = trustprovider.GetTrustProviderKindFromProfile(opts.profile)
-		if err != nil {
-			return err
-		}
-	}
-
 	bundleEndpointProfile := trust_zone_proto.BundleEndpointProfile_BUNDLE_ENDPOINT_PROFILE_HTTPS_SPIFFE
 
 	newTrustZone := &trust_zone_proto.TrustZone{
@@ -207,50 +168,12 @@ func (c *TrustZoneCommand) addTrustZone(ctx context.Context, opts addOpts, ds da
 		BundleEndpointProfile: &bundleEndpointProfile,
 	}
 
-	receivedTz, err := ds.AddTrustZone(newTrustZone)
+	_, err := ds.AddTrustZone(newTrustZone)
 	if err != nil {
 		return fmt.Errorf("failed to create trust zone %s: %w", newTrustZone.GetName(), err)
 	}
 
-	newTrustZone = receivedTz
-
-	if !opts.noCluster {
-		var caBytes []byte
-		if opts.kubernetesClusterCACert != "" {
-			caBytes, err = parseKubernetesCACertFromPath(opts.kubernetesClusterCACert)
-			if err != nil {
-				return fmt.Errorf("failed to create cluster with CA cert %w", err)
-			}
-		}
-
-		newCluster := &clusterpb.Cluster{
-			Name:              &opts.kubernetesCluster,
-			TrustZoneId:       newTrustZone.Id,
-			KubernetesContext: &opts.context,
-			TrustProvider:     &trust_provider_proto.TrustProvider{Kind: &trustProviderKind},
-			Profile:           &opts.profile,
-			ExternalServer:    &opts.externalServer,
-			OidcIssuerUrl:     &opts.kubernetesClusterOIDCIssuerURL,
-		}
-
-		if caBytes != nil {
-			newCluster.OidcIssuerCaCert = caBytes
-		}
-
-		_, err = ds.AddCluster(newCluster)
-		if err != nil {
-			if err := ds.DestroyTrustZone(newTrustZone.GetId()); err != nil {
-				slog.Error("Failed to destroy trust zone during rollback", "error", err)
-			}
-			return fmt.Errorf("failed to create cluster %s: %w", newCluster.GetName(), err)
-		}
-	}
-
 	return nil
-}
-
-func parseKubernetesCACertFromPath(path string) ([]byte, error) {
-	return os.ReadFile(path)
 }
 
 var trustZoneDelCmdDesc = `
@@ -491,99 +414,11 @@ func renderStatus(trustZone *trust_zone_proto.TrustZone, server *spire.ServerSta
 	return err
 }
 
-func (c *TrustZoneCommand) getKubernetesContext(cmd *cobra.Command, opts *addOpts) error {
-	kubeConfig, err := cmd.Flags().GetString("kube-config")
-	if err != nil {
-		return err
-	}
-	client, err := kubeutil.NewKubeClient(kubeConfig)
-	if err != nil {
-		return err
-	}
-
-	kubeRepo := kubeutil.NewKubeRepository(client)
-	contexts, err := kubeRepo.GetContexts()
-	if err != nil {
-		return err
-	}
-
-	if opts.context != "" {
-		if checkContext(contexts, opts.context) {
-			return nil
-		}
-		return fmt.Errorf("could not find kubectl context '%s'", opts.context)
-	}
-
-	opts.context, err = promptContext(contexts, client.CmdConfig.CurrentContext)
-	return err
-}
-
-func promptContext(contexts []string, currentContext string) (string, error) {
-	curPos := 0
-	if currentContext != "" {
-		curPos = slices.Index(contexts, currentContext)
-	}
-
-	prompt := promptui.Select{
-		Label:     "Select kubectl context to use",
-		Items:     contexts,
-		CursorPos: curPos,
-	}
-
-	_, result, err := prompt.Run()
-	if err != nil {
-		return "", err
-	}
-
-	return result, nil
-}
-
-func checkContext(contexts []string, context string) bool {
-	return slices.Contains(contexts, context)
-}
-
 func validateOpts(opts addOpts) error {
 	_, err := spiffeid.TrustDomainFromString(opts.trustDomain)
 	if err != nil {
 		return err
 	}
 
-	normalisedURL, err := validateAndParseOIDCIssuerURL(opts.kubernetesClusterOIDCIssuerURL)
-	if err != nil {
-		return fmt.Errorf("invalid --kubernetes-oidc-issuer: %w", err)
-	}
-	opts.kubernetesClusterOIDCIssuerURL = normalisedURL
-
 	return nil
-}
-
-func validateAndParseOIDCIssuerURL(oidcIssuerURL string) (string, error) {
-	// It's an optional flag, so if it's empty, it's valid.
-	if oidcIssuerURL == "" {
-		return "", nil
-	}
-
-	u, err := url.ParseRequestURI(oidcIssuerURL)
-	if err != nil {
-		return "", fmt.Errorf("invalid URL format: %w", err)
-	}
-
-	if u.Scheme != "https" {
-		return "", fmt.Errorf("URL scheme must be 'https', but got '%s'", u.Scheme)
-	}
-
-	if u.Host == "" {
-		return "", fmt.Errorf("URL must include a host")
-	}
-
-	if u.RawQuery != "" {
-		return "", fmt.Errorf("URL must not have a query component")
-	}
-
-	if u.Fragment != "" {
-		return "", fmt.Errorf("URL must not have a fragment component")
-	}
-
-	u.Path = strings.TrimRight(u.Path, "/")
-	return u.String(), nil
 }

--- a/cmd/cofidectl/cmd/trustzone/trustzone_test.go
+++ b/cmd/cofidectl/cmd/trustzone/trustzone_test.go
@@ -4,24 +4,11 @@
 package trustzone
 
 import (
-	"bytes"
 	"context"
-	"crypto/rand"
-	"crypto/rsa"
-	"crypto/x509"
-	"crypto/x509/pkix"
-	"encoding/pem"
 	"errors"
-	"fmt"
-	"math/big"
-	"os"
 	"testing"
-	"time"
 
-	clusterpb "github.com/cofide/cofide-api-sdk/gen/go/proto/cluster/v1alpha1"
-	datasourcepb "github.com/cofide/cofide-api-sdk/gen/go/proto/cofidectl/datasource_plugin/v1alpha2"
 	trust_zone_proto "github.com/cofide/cofide-api-sdk/gen/go/proto/trust_zone/v1alpha1"
-	"github.com/cofide/cofide-api-sdk/pkg/connect/client/test"
 	"github.com/cofide/cofidectl/internal/pkg/config"
 	"github.com/cofide/cofidectl/internal/pkg/test/fixtures"
 	"github.com/cofide/cofidectl/pkg/plugin/datasource"
@@ -30,15 +17,12 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-const fakeOIDCIssuerURL = "https://some.oidc"
-
 func TestValidateOpts(t *testing.T) {
 	// https://github.com/spiffe/spiffe/blob/main/standards/SPIFFE-ID.md#21-trust-domain
 	tt := []struct {
-		name          string
-		domain        string
-		oidcIssuerURL string
-		errExpected   bool
+		name        string
+		domain      string
+		errExpected bool
 	}{
 		{domain: "example.com", errExpected: false},
 		{domain: "example-domain.com", errExpected: false},
@@ -49,17 +33,11 @@ func TestValidateOpts(t *testing.T) {
 		{domain: "user:password@example.com", errExpected: true},
 		{domain: "example?.com", errExpected: true},
 		{domain: "exam%3Aple.com", errExpected: true},
-		{domain: "valid.com", oidcIssuerURL: "https://valid.oidc", errExpected: false},
-		{domain: "valid.com", oidcIssuerURL: "https://validwithport.oidc:644", errExpected: false},
-		{domain: "valid.com", oidcIssuerURL: "h://invalid.oidc", errExpected: true},
-		{domain: "INVALID.COM", oidcIssuerURL: "https://valid.oidc", errExpected: true},
-		{domain: "valid.com", oidcIssuerURL: "http://valid.oidc", errExpected: true},
-		{domain: "valid.com", oidcIssuerURL: "https://valid.oidc/", errExpected: false},
 	}
 
 	for _, tc := range tt {
 		t.Run(tc.domain, func(t *testing.T) {
-			err := validateOpts(addOpts{trustDomain: tc.domain, kubernetesClusterOIDCIssuerURL: tc.oidcIssuerURL})
+			err := validateOpts(addOpts{trustDomain: tc.domain})
 			assert.Equal(t, tc.errExpected, err != nil)
 		})
 	}
@@ -70,24 +48,12 @@ func TestTrustZoneCommand_addTrustZone(t *testing.T) {
 		name           string
 		trustZoneName  string
 		injectFailure  bool
-		withOIDCIssuer bool
-		withKubeCACert bool
 		wantErr        bool
 		wantErrMessage string
 	}{
 		{
 			name:          "success",
 			trustZoneName: "tz3",
-		},
-		{
-			name:           "success with OIDC issuer",
-			trustZoneName:  "tz-oidc",
-			withOIDCIssuer: true,
-		},
-		{
-			name:           "success with kube CA cert",
-			trustZoneName:  "tz-ca-cert",
-			withKubeCACert: true,
 		},
 		{
 			name:           "already exists",
@@ -110,34 +76,8 @@ func TestTrustZoneCommand_addTrustZone(t *testing.T) {
 				ds = &failingDS{LocalDataSource: ds.(*local.LocalDataSource)}
 			}
 			opts := addOpts{
-				name:              tt.trustZoneName,
-				trustDomain:       "td3",
-				kubernetesCluster: "local3",
-				context:           "kind-local3",
-				profile:           "kubernetes",
-				noCluster:         false,
-			}
-
-			if tt.withOIDCIssuer {
-				opts.kubernetesClusterOIDCIssuerURL = fakeOIDCIssuerURL
-			}
-
-			if tt.withKubeCACert {
-				var err error
-				caString, err := getFakeKubeCACert()
-				require.NoError(t, err)
-
-				tmpFile, err := os.CreateTemp("", "cert-*.pem")
-				require.NoError(t, err)
-				defer func() {
-					err := tmpFile.Close()
-					require.NoError(t, err)
-				}()
-
-				_, err = tmpFile.WriteString(caString)
-				require.NoError(t, err)
-
-				opts.kubernetesClusterCACert = tmpFile.Name()
+				name:        tt.trustZoneName,
+				trustDomain: "td3",
 			}
 
 			c := TrustZoneCommand{}
@@ -155,68 +95,19 @@ func TestTrustZoneCommand_addTrustZone(t *testing.T) {
 			} else {
 				require.NoError(t, err)
 
-				// Check that trust zone and cluster were added.
+				// Check that trust zone was added.
 				trustZone, err := ds.GetTrustZoneByName(tt.trustZoneName)
 				require.NoError(t, err)
 				require.NotNil(t, trustZone)
-
-				clusters, err := ds.ListClusters(&datasourcepb.ListClustersRequest_Filter{
-					TrustZoneId: trustZone.Id,
-				})
-				require.NoError(t, err)
-				require.Len(t, clusters, 1)
-				assert.Equal(t, "local3", clusters[0].GetName())
-
-				if tt.withOIDCIssuer {
-					assert.Equal(t, fakeOIDCIssuerURL, clusters[0].GetOidcIssuerUrl())
-				}
-
-				if tt.withKubeCACert {
-					caBytes, err := os.ReadFile(opts.kubernetesClusterCACert)
-					require.NoError(t, err)
-					assert.Equal(t, caBytes, clusters[0].GetOidcIssuerCaCert())
-				}
 			}
 		})
 	}
-}
-
-func getFakeKubeCACert() (string, error) {
-	priv, err := rsa.GenerateKey(rand.Reader, 2048)
-	if err != nil {
-		return "", fmt.Errorf("failed to generate private key: %w", err)
-	}
-
-	template := x509.Certificate{
-		SerialNumber: big.NewInt(1),
-		Subject: pkix.Name{
-			Organization: []string{"Fake Kubernetes CA"},
-		},
-		NotBefore:             time.Now(),
-		NotAfter:              time.Now().Add(time.Hour),
-		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageDigitalSignature,
-		BasicConstraintsValid: true,
-		IsCA:                  true,
-	}
-
-	derBytes, err := x509.CreateCertificate(rand.Reader, &template, &template, &priv.PublicKey, priv)
-	if err != nil {
-		return "", fmt.Errorf("failed to create certificate: %w", err)
-	}
-
-	var certPEM bytes.Buffer
-	if err := pem.Encode(&certPEM, &pem.Block{Type: "CERTIFICATE", Bytes: derBytes}); err != nil {
-		return "", fmt.Errorf("failed to encode cert to PEM: %w", err)
-	}
-
-	return certPEM.String(), nil
 }
 
 func TestTrustZoneCommand_deleteTrustZone(t *testing.T) {
 	tests := []struct {
 		name           string
 		trustZoneName  string
-		injectFailure  bool
 		wantErr        bool
 		wantErrMessage string
 	}{
@@ -230,20 +121,10 @@ func TestTrustZoneCommand_deleteTrustZone(t *testing.T) {
 			wantErr:        true,
 			wantErrMessage: "failed to find trust zone invalid tz in local config",
 		},
-		{
-			name:           "cluster delete rollback",
-			trustZoneName:  "tz1",
-			injectFailure:  true,
-			wantErr:        true,
-			wantErrMessage: "fake destroy failure",
-		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			ds := newFakeDataSource(t, defaultConfig())
-			if tt.injectFailure {
-				ds = &failingDS{LocalDataSource: ds.(*local.LocalDataSource)}
-			}
 			err := deleteTrustZone(context.Background(), tt.trustZoneName, ds, "", true)
 			if tt.wantErr {
 				require.Error(t, err)
@@ -252,15 +133,6 @@ func TestTrustZoneCommand_deleteTrustZone(t *testing.T) {
 				// Check that trust zone and clusters were not deleted.
 				_, err := ds.GetTrustZone("tz1-id")
 				require.NoError(t, err)
-				if tt.injectFailure {
-					// Currently the local datasource limits us to one cluster per trust zone, so rolling back deletion fails.
-					assert.Equal(t, 1, ds.(*failingDS).clustersAdded)
-				} else {
-					for _, cluster := range defaultConfig().Clusters {
-						_, err := ds.GetCluster(cluster.GetId())
-						require.NoError(t, err)
-					}
-				}
 			} else {
 				require.NoError(t, err)
 
@@ -278,28 +150,11 @@ func TestTrustZoneCommand_deleteTrustZone(t *testing.T) {
 
 type failingDS struct {
 	*local.LocalDataSource
-	clustersDestroyed int
-	clustersAdded     int
 }
 
 // AddTrustZone fails unconditionally.
 func (f *failingDS) AddTrustZone(trustZone *trust_zone_proto.TrustZone) (*trust_zone_proto.TrustZone, error) {
 	return nil, errors.New("fake add failure")
-}
-
-// AddCluster keeps track of the number of clusters added.
-func (f *failingDS) AddCluster(cluster *clusterpb.Cluster) (*clusterpb.Cluster, error) {
-	f.clustersAdded++
-	return f.LocalDataSource.AddCluster(cluster)
-}
-
-// DestroyCluster fails when a second cluster is destroyed, allowing testing of rollback.
-func (f *failingDS) DestroyCluster(id string) error {
-	f.clustersDestroyed++
-	if f.clustersDestroyed == 2 {
-		return errors.New("fake destroy failure")
-	}
-	return f.LocalDataSource.DestroyCluster(id)
 }
 
 func newFakeDataSource(t *testing.T, cfg *config.Config) datasource.DataSource {
@@ -314,14 +169,6 @@ func defaultConfig() *config.Config {
 	return &config.Config{
 		TrustZones: []*trust_zone_proto.TrustZone{
 			fixtures.TrustZone("tz1"),
-		},
-		Clusters: []*clusterpb.Cluster{
-			fixtures.Cluster("local1"),
-			func() *clusterpb.Cluster {
-				cluster := fixtures.Cluster("local1")
-				cluster.Name = test.PtrOf("local2")
-				return cluster
-			}(),
 		},
 		Plugins: fixtures.Plugins("plugins1"),
 	}

--- a/docs/multi-tz-federation.md
+++ b/docs/multi-tz-federation.md
@@ -9,7 +9,8 @@ In this example, the workloads will instead be in separate trust zones, with dis
 Let's add an additional trust-zone (`cofide-b`) in a new `kind` cluster (in this case, `kind2`) and a Cofide federation between them:
 
 ```sh
-./cofidectl trust-zone add cofide-b --trust-domain cofide-b.test --kubernetes-cluster kind2 --profile kubernetes --kubernetes-context kind-kind2
+./cofidectl trust-zone add cofide-b --trust-domain cofide-b.test
+./cofidectl cluster add kind2 --trust-zone cofide-b --profile kubernetes --kubernetes-context kind-kind2
 ./cofidectl federation add --from cofide-a --to cofide-b
 ./cofidectl federation add --from cofide-b --to cofide-a
 ```

--- a/tests/integration/external-agent/test.sh
+++ b/tests/integration/external-agent/test.sh
@@ -34,8 +34,7 @@ PING_PONG_SERVER_DNS_NAME=ping-pong-server.example.org
 
 function configure() {
   ./cofidectl trust-zone add $TRUST_ZONE \
-    --trust-domain $TRUST_DOMAIN \
-    --no-cluster
+    --trust-domain $TRUST_DOMAIN
   ./cofidectl cluster add $K8S_CLUSTER_NAME \
     --trust-zone $TRUST_ZONE \
     --kubernetes-context $K8S_CLUSTER_CONTEXT \

--- a/tests/integration/federation/test.sh
+++ b/tests/integration/federation/test.sh
@@ -39,8 +39,10 @@ function check_init() {
 }
 
 function configure_trust_zones() {
-  ./cofidectl trust-zone add $TRUST_ZONE_1 --trust-domain $TRUST_DOMAIN_1 --kubernetes-context $K8S_CLUSTER_1_CONTEXT --kubernetes-cluster $K8S_CLUSTER_1_NAME --profile kubernetes
-  ./cofidectl trust-zone add $TRUST_ZONE_2 --trust-domain $TRUST_DOMAIN_2 --kubernetes-context $K8S_CLUSTER_2_CONTEXT --kubernetes-cluster $K8S_CLUSTER_2_NAME --profile kubernetes
+  ./cofidectl trust-zone add $TRUST_ZONE_1 --trust-domain $TRUST_DOMAIN_1
+  ./cofidectl cluster add $K8S_CLUSTER_1_NAME --trust-zone $TRUST_ZONE_1 --kubernetes-context $K8S_CLUSTER_1_CONTEXT --profile kubernetes
+  ./cofidectl trust-zone add $TRUST_ZONE_2 --trust-domain $TRUST_DOMAIN_2
+  ./cofidectl cluster add $K8S_CLUSTER_2_NAME --trust-zone $TRUST_ZONE_2 --kubernetes-context $K8S_CLUSTER_2_CONTEXT --profile kubernetes
  }
 
 function configure_federations() {

--- a/tests/integration/single-trust-zone/test.sh
+++ b/tests/integration/single-trust-zone/test.sh
@@ -20,7 +20,7 @@ NAMESPACE_POLICY_NAMESPACE=${NAMESPACE_POLICY_NAMESPACE:-demo}
 POD_POLICY_POD_LABEL=${POD_POLICY_POD_LABEL:-"foo=bar"}
 
 function configure() {
-  ./cofidectl trust-zone add $TRUST_ZONE --trust-domain $TRUST_DOMAIN --no-cluster
+  ./cofidectl trust-zone add $TRUST_ZONE --trust-domain $TRUST_DOMAIN
   ./cofidectl cluster add $K8S_CLUSTER_NAME --trust-zone $TRUST_ZONE --kubernetes-context $K8S_CLUSTER_CONTEXT --profile kubernetes
   ./cofidectl attestation-policy add kubernetes --name namespace --namespace $NAMESPACE_POLICY_NAMESPACE --spiffeid-path-template 'ns/{{ .PodMeta.Namespace }}/sa/{{ .PodSpec.ServiceAccountName }}'
   ./cofidectl attestation-policy add kubernetes --name pod-label --pod-label $POD_POLICY_POD_LABEL --dnsNameTemplates example.namespace.svc.cluster.local


### PR DESCRIPTION
Removes support for creating a cluster at the same time as creating a trust zone to simplify resource management (not adding multiple resource types in a single command).

This is a breaking change, any usage of `cofidectl trust-zone add` that was creating a cluster at the same time now needs splitting into 2 commands (`cofidectl trust-zone add ... && cofidectl cluster add ...`). This has already been done in https://github.com/cofide/cofide-connect in PR https://github.com/cofide/cofide-connect/pull/1616. So the same approach can be applied to the rest of our repositories.