### PR TITLE
chore: update Go to 1.25.9

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/cofide/cofidectl
 
-go 1.25.8
+go 1.25.9
 
 require (
 	buf.build/go/protoyaml v0.6.0


### PR DESCRIPTION
Fixes:

GO-2026-4947
    Unexpected work during chain building in crypto/x509
GO-2026-4946
    Inefficient policy validation in crypto/x509
GO-2026-4870
    Unauthenticated TLS 1.3 KeyUpdate record can cause persistent connection
    retention and DoS in crypto/tls
GO-2026-4869
    Unbounded allocation for old GNU sparse in archive/tar
GO-2026-4865
    JsBraceDepth Context Tracking Bugs (XSS) in html/template
