### PR TITLE
Add attestation-policy-binding update subcommand

### DIFF
--- a/cmd/cofidectl/cmd/apbinding/apbinding.go
+++ b/cmd/cofidectl/cmd/apbinding/apbinding.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"slices"
 	"strings"
 
 	ap_binding_proto "github.com/cofide/cofide-api-sdk/gen/go/proto/ap_binding/v1alpha1"
@@ -44,6 +45,7 @@ func (c *APBindingCommand) GetRootCommand() *cobra.Command {
 		c.GetListCommand(),
 		c.GetAddCommand(),
 		c.GetDelCommand(),
+		c.GetUpdateCommand(),
 	)
 
 	return cmd
@@ -287,4 +289,100 @@ func (c *APBindingCommand) GetDelCommand() *cobra.Command {
 	cobra.CheckErr(cmd.MarkFlagRequired("attestation-policy"))
 
 	return cmd
+}
+
+var apBindingUpdateCmdDesc = `
+This command will update an attestation policy binding in the Cofide configuration state.`
+
+type updateOpts struct {
+	trustZone         string
+	attestationPolicy string
+	federatesWith     []string
+}
+
+func (c *APBindingCommand) GetUpdateCommand() *cobra.Command {
+	opts := updateOpts{}
+	cmd := &cobra.Command{
+		Use:   "update [ARGS]",
+		Short: "Update an attestation policy binding",
+		Long:  apBindingUpdateCmdDesc,
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ds, err := c.cmdCtx.PluginManager.GetDataSource(cmd.Context())
+			if err != nil {
+				return err
+			}
+			return c.updateAPBinding(opts, cmd, ds)
+		},
+	}
+
+	f := cmd.Flags()
+	f.StringVar(&opts.trustZone, "trust-zone", "", "Trust zone name")
+	f.StringVar(&opts.attestationPolicy, "attestation-policy", "", "Attestation policy name")
+	f.StringSliceVar(&opts.federatesWith, "federates-with", nil, "Defines a trust zone to federate identity with. May be specified multiple times")
+
+	cobra.CheckErr(cmd.MarkFlagRequired("trust-zone"))
+	cobra.CheckErr(cmd.MarkFlagRequired("attestation-policy"))
+
+	return cmd
+}
+
+func (c *APBindingCommand) updateAPBinding(opts updateOpts, cmd *cobra.Command, ds datasource.DataSource) error {
+	updatableFlags := []string{"federates-with"}
+	if !slices.ContainsFunc(updatableFlags, cmd.Flags().Changed) {
+		fmt.Println("No changes specified")
+		return nil
+	}
+
+	trustZone, err := ds.GetTrustZoneByName(opts.trustZone)
+	if err != nil {
+		return fmt.Errorf("failed to get trust zone %s: %w", opts.trustZone, err)
+	}
+
+	policy, err := ds.GetAttestationPolicyByName(opts.attestationPolicy)
+	if err != nil {
+		return fmt.Errorf("failed to get attestation policy %s: %w", opts.attestationPolicy, err)
+	}
+
+	bindings, err := ds.ListAPBindings(&datasourcepb.ListAPBindingsRequest_Filter{
+		TrustZoneId: trustZone.Id,
+		PolicyId:    policy.Id,
+	})
+	if err != nil {
+		return err
+	}
+	if len(bindings) == 0 {
+		return errors.New("no binding found")
+	}
+	if len(bindings) > 1 {
+		return errors.New("multiple bindings found")
+	}
+	binding := bindings[0]
+
+	if cmd.Flags().Changed("federates-with") {
+		tzs, err := ds.ListTrustZones()
+		if err != nil {
+			return err
+		}
+		federations := []*ap_binding_proto.APBindingFederation{}
+		for _, federation := range opts.federatesWith {
+			var fedTZ *trustzonepb.TrustZone
+			for _, tz := range tzs {
+				if tz.Name == federation {
+					fedTZ = tz
+					break
+				}
+			}
+			if fedTZ == nil {
+				return fmt.Errorf("federated trust zone not found: %s", federation)
+			}
+			federations = append(federations, &ap_binding_proto.APBindingFederation{
+				TrustZoneId: fedTZ.Id,
+			})
+		}
+		binding.Federations = federations
+	}
+
+	_, err = ds.UpdateAPBinding(binding)
+	return err
 }

--- a/cmd/cofidectl/cmd/apbinding/apbinding.go
+++ b/cmd/cofidectl/cmd/apbinding/apbinding.go
@@ -14,9 +14,9 @@ import (
 	datasourcepb "github.com/cofide/cofide-api-sdk/gen/go/proto/cofidectl/datasource_plugin/v1alpha2"
 	trustzonepb "github.com/cofide/cofide-api-sdk/gen/go/proto/trust_zone/v1alpha1"
 	"github.com/cofide/cofidectl/cmd/cofidectl/cmd/renderer"
-	"github.com/spf13/cobra"
 	cmdcontext "github.com/cofide/cofidectl/pkg/cmd/context"
 	"github.com/cofide/cofidectl/pkg/plugin/datasource"
+	"github.com/spf13/cobra"
 )
 
 type APBindingCommand struct {
@@ -292,19 +292,22 @@ func (c *APBindingCommand) GetDelCommand() *cobra.Command {
 }
 
 var apBindingUpdateCmdDesc = `
-This command will update an attestation policy binding in the Cofide configuration state.`
+This command will update an existing attestation policy binding.
+Only the federations can be updated, so one of --federates-with
+or --clear-federations must be provided.`
 
 type updateOpts struct {
 	trustZone         string
 	attestationPolicy string
 	federatesWith     []string
+	clearFederations  bool
 }
 
 func (c *APBindingCommand) GetUpdateCommand() *cobra.Command {
 	opts := updateOpts{}
 	cmd := &cobra.Command{
 		Use:   "update [ARGS]",
-		Short: "Update an attestation policy binding",
+		Short: "Update an attestation policy binding.",
 		Long:  apBindingUpdateCmdDesc,
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -319,7 +322,8 @@ func (c *APBindingCommand) GetUpdateCommand() *cobra.Command {
 	f := cmd.Flags()
 	f.StringVar(&opts.trustZone, "trust-zone", "", "Trust zone name")
 	f.StringVar(&opts.attestationPolicy, "attestation-policy", "", "Attestation policy name")
-	f.StringSliceVar(&opts.federatesWith, "federates-with", nil, "Defines a trust zone to federate identity with. May be specified multiple times")
+	f.StringSliceVar(&opts.federatesWith, "federates-with", nil, "Defines a trust zone to federate identity with. May be specified multiple times. Conflicts with --clear-federations")
+	f.BoolVar(&opts.clearFederations, "clear-federations", false, "Specify to clear all federations from the binding. Conflicts with --federates-with")
 
 	cobra.CheckErr(cmd.MarkFlagRequired("trust-zone"))
 	cobra.CheckErr(cmd.MarkFlagRequired("attestation-policy"))
@@ -328,10 +332,14 @@ func (c *APBindingCommand) GetUpdateCommand() *cobra.Command {
 }
 
 func (c *APBindingCommand) updateAPBinding(opts updateOpts, cmd *cobra.Command, ds datasource.DataSource) error {
-	updatableFlags := []string{"federates-with"}
+	updatableFlags := []string{"federates-with", "clear-federations"}
 	if !slices.ContainsFunc(updatableFlags, cmd.Flags().Changed) {
 		fmt.Println("No changes specified")
 		return nil
+	}
+
+	if cmd.Flags().Changed("federates-with") && cmd.Flags().Changed("clear-federations") {
+		return errors.New("cannot simultaneously specify --federates-with and --clear-federations")
 	}
 
 	trustZone, err := ds.GetTrustZoneByName(opts.trustZone)
@@ -359,25 +367,30 @@ func (c *APBindingCommand) updateAPBinding(opts updateOpts, cmd *cobra.Command, 
 	}
 	binding := bindings[0]
 
-	if cmd.Flags().Changed("federates-with") {
+	if cmd.Flags().Changed("clear-federations") && opts.clearFederations {
+		binding.Federations = nil
+	}
+
+	if cmd.Flags().Changed("federates-with") && len(opts.federatesWith) > 0 {
+		federations := []*ap_binding_proto.APBindingFederation{}
 		tzs, err := ds.ListTrustZones()
 		if err != nil {
 			return err
 		}
-		federations := []*ap_binding_proto.APBindingFederation{}
+
 		for _, federation := range opts.federatesWith {
-			var fedTZ *trustzonepb.TrustZone
+			var trustZone *trustzonepb.TrustZone
 			for _, tz := range tzs {
 				if tz.Name == federation {
-					fedTZ = tz
+					trustZone = tz
 					break
 				}
 			}
-			if fedTZ == nil {
+			if trustZone == nil {
 				return fmt.Errorf("federated trust zone not found: %s", federation)
 			}
 			federations = append(federations, &ap_binding_proto.APBindingFederation{
-				TrustZoneId: fedTZ.Id,
+				TrustZoneId: trustZone.Id,
 			})
 		}
 		binding.Federations = federations

--- a/cmd/cofidectl/cmd/apbinding/apbinding.go
+++ b/cmd/cofidectl/cmd/apbinding/apbinding.go
@@ -174,50 +174,7 @@ func (c *APBindingCommand) GetAddCommand() *cobra.Command {
 			if err != nil {
 				return err
 			}
-
-			tz, err := ds.GetTrustZoneByName(opts.trustZone)
-			if err != nil {
-				return err
-			}
-			trustZoneID := tz.GetId()
-
-			policy, err := ds.GetAttestationPolicyByName(opts.attestationPolicy)
-			if err != nil {
-				return err
-			}
-			policyID := policy.GetId()
-
-			federations := []*ap_binding_proto.APBindingFederation{}
-			if len(opts.federatesWith) != 0 {
-				tzs, err := ds.ListTrustZones()
-				if err != nil {
-					return err
-				}
-
-				for _, federation := range opts.federatesWith {
-					var trustZone *trustzonepb.TrustZone
-					for _, tz := range tzs {
-						if tz.Name == federation {
-							trustZone = tz
-							break
-						}
-					}
-					if trustZone == nil {
-						return fmt.Errorf("federated trust zone not found: %s", federation)
-					}
-					federations = append(federations, &ap_binding_proto.APBindingFederation{
-						TrustZoneId: trustZone.Id,
-					})
-				}
-			}
-
-			binding := &ap_binding_proto.APBinding{
-				TrustZoneId: &trustZoneID,
-				PolicyId:    &policyID,
-				Federations: federations,
-			}
-			_, err = ds.AddAPBinding(binding)
-			return err
+			return c.addAPBinding(opts, ds)
 		},
 	}
 
@@ -230,6 +187,52 @@ func (c *APBindingCommand) GetAddCommand() *cobra.Command {
 	cobra.CheckErr(cmd.MarkFlagRequired("attestation-policy"))
 
 	return cmd
+}
+
+func (c *APBindingCommand) addAPBinding(opts AddOpts, ds datasource.DataSource) error {
+	tz, err := ds.GetTrustZoneByName(opts.trustZone)
+	if err != nil {
+		return err
+	}
+	trustZoneID := tz.GetId()
+
+	policy, err := ds.GetAttestationPolicyByName(opts.attestationPolicy)
+	if err != nil {
+		return err
+	}
+	policyID := policy.GetId()
+
+	federations := []*ap_binding_proto.APBindingFederation{}
+	if len(opts.federatesWith) != 0 {
+		tzs, err := ds.ListTrustZones()
+		if err != nil {
+			return err
+		}
+
+		for _, federation := range opts.federatesWith {
+			var trustZone *trustzonepb.TrustZone
+			for _, tz := range tzs {
+				if tz.Name == federation {
+					trustZone = tz
+					break
+				}
+			}
+			if trustZone == nil {
+				return fmt.Errorf("federated trust zone not found: %s", federation)
+			}
+			federations = append(federations, &ap_binding_proto.APBindingFederation{
+				TrustZoneId: trustZone.Id,
+			})
+		}
+	}
+
+	binding := &ap_binding_proto.APBinding{
+		TrustZoneId: &trustZoneID,
+		PolicyId:    &policyID,
+		Federations: federations,
+	}
+	_, err = ds.AddAPBinding(binding)
+	return err
 }
 
 var apBindingDelCmdDesc = `

--- a/cmd/cofidectl/cmd/apbinding/apbinding_test.go
+++ b/cmd/cofidectl/cmd/apbinding/apbinding_test.go
@@ -1,0 +1,207 @@
+// Copyright 2024 Cofide Limited.
+// SPDX-License-Identifier: Apache-2.0
+
+package apbinding
+
+import (
+	"errors"
+	"testing"
+
+	ap_binding_proto "github.com/cofide/cofide-api-sdk/gen/go/proto/ap_binding/v1alpha1"
+	attestation_policy_proto "github.com/cofide/cofide-api-sdk/gen/go/proto/attestation_policy/v1alpha1"
+	federation_proto "github.com/cofide/cofide-api-sdk/gen/go/proto/federation/v1alpha1"
+	trust_zone_proto "github.com/cofide/cofide-api-sdk/gen/go/proto/trust_zone/v1alpha1"
+	"github.com/cofide/cofidectl/internal/pkg/config"
+	"github.com/cofide/cofidectl/internal/pkg/test/fixtures"
+	"github.com/cofide/cofidectl/pkg/plugin/datasource"
+	"github.com/cofide/cofidectl/pkg/plugin/local"
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAPBindingCommand_updateAPBinding(t *testing.T) {
+	tests := []struct {
+		name                     string
+		trustZoneName            string
+		attestationPolicyName    string
+		flags                    map[string]string
+		injectFailure            bool
+		wantErr                  bool
+		wantErrMessage           string
+		nonExistentTrustZone     bool
+		nonExistentPolicy        bool
+		nonExistentBinding       bool
+		wantCheck                func(t *testing.T, binding *ap_binding_proto.APBinding)
+	}{
+		{
+			name:                  "update federates-with",
+			trustZoneName:         "tz1",
+			attestationPolicyName: "ap1",
+			flags:                 map[string]string{"federates-with": "tz2"},
+			wantCheck: func(t *testing.T, binding *ap_binding_proto.APBinding) {
+				require.Len(t, binding.GetFederations(), 1)
+				assert.Equal(t, "tz2-id", binding.GetFederations()[0].GetTrustZoneId())
+			},
+		},
+		{
+			name:                  "clear federations with empty list",
+			trustZoneName:         "tz1",
+			attestationPolicyName: "ap1",
+			flags:                 map[string]string{"federates-with": ""},
+			wantCheck: func(t *testing.T, binding *ap_binding_proto.APBinding) {
+				assert.Empty(t, binding.GetFederations())
+			},
+		},
+		{
+			name:                  "no flags set leaves binding unchanged",
+			trustZoneName:         "tz1",
+			attestationPolicyName: "ap1",
+			flags:                 map[string]string{},
+			wantCheck: func(t *testing.T, binding *ap_binding_proto.APBinding) {
+				require.Len(t, binding.GetFederations(), 1)
+				assert.Equal(t, "tz2-id", binding.GetFederations()[0].GetTrustZoneId())
+			},
+		},
+		{
+			name:                  "non-existent trust zone",
+			trustZoneName:         "tz-missing",
+			attestationPolicyName: "ap1",
+			flags:                 map[string]string{"federates-with": "tz2"},
+			wantErr:               true,
+			wantErrMessage:        "failed to get trust zone tz-missing",
+			nonExistentTrustZone:  true,
+		},
+		{
+			name:                  "non-existent attestation policy",
+			trustZoneName:         "tz1",
+			attestationPolicyName: "ap-missing",
+			flags:                 map[string]string{"federates-with": "tz2"},
+			wantErr:               true,
+			wantErrMessage:        "failed to get attestation policy ap-missing",
+			nonExistentPolicy:     true,
+		},
+		{
+			name:                  "non-existent binding",
+			trustZoneName:         "tz1",
+			attestationPolicyName: "ap2",
+			flags:                 map[string]string{"federates-with": "tz2"},
+			wantErr:               true,
+			wantErrMessage:        "no binding found",
+			nonExistentBinding:    true,
+		},
+		{
+			name:                  "invalid federated trust zone",
+			trustZoneName:         "tz1",
+			attestationPolicyName: "ap1",
+			flags:                 map[string]string{"federates-with": "tz-missing"},
+			wantErr:               true,
+			wantErrMessage:        "federated trust zone not found: tz-missing",
+		},
+		{
+			name:                  "datastore failure",
+			trustZoneName:         "tz1",
+			attestationPolicyName: "ap1",
+			flags:                 map[string]string{"federates-with": "tz2"},
+			injectFailure:         true,
+			wantErr:               true,
+			wantErrMessage:        "fake update failure",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ds := newFakeDataSource(t, defaultConfig())
+			if tt.injectFailure {
+				ds = &failingUpdateDS{LocalDataSource: ds.(*local.LocalDataSource)}
+			}
+
+			cmd := buildUpdateCmd(tt.flags)
+
+			opts := updateOpts{
+				trustZone:         tt.trustZoneName,
+				attestationPolicy: tt.attestationPolicyName,
+			}
+			if val, ok := tt.flags["federates-with"]; ok {
+				opts.federatesWith = []string{val}
+				if val == "" {
+					opts.federatesWith = []string{}
+				}
+			}
+
+			c := APBindingCommand{}
+			err := c.updateAPBinding(opts, cmd, ds)
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.ErrorContains(t, err, tt.wantErrMessage)
+			} else {
+				require.NoError(t, err)
+				tz, err := ds.GetTrustZoneByName(tt.trustZoneName)
+				require.NoError(t, err)
+				ap, err := ds.GetAttestationPolicyByName(tt.attestationPolicyName)
+				require.NoError(t, err)
+				bindings, err := ds.ListAPBindings(nil)
+				require.NoError(t, err)
+				var binding *ap_binding_proto.APBinding
+				for _, b := range bindings {
+					if b.GetTrustZoneId() == tz.GetId() && b.GetPolicyId() == ap.GetId() {
+						binding = b
+						break
+					}
+				}
+				require.NotNil(t, binding)
+				tt.wantCheck(t, binding)
+			}
+		})
+	}
+}
+
+func buildUpdateCmd(flags map[string]string) *cobra.Command {
+	opts := updateOpts{}
+	cmd := &cobra.Command{}
+	f := cmd.Flags()
+	f.StringVar(&opts.trustZone, "trust-zone", "", "")
+	f.StringVar(&opts.attestationPolicy, "attestation-policy", "", "")
+	f.StringSliceVar(&opts.federatesWith, "federates-with", nil, "")
+	for name, val := range flags {
+		cobra.CheckErr(cmd.Flags().Set(name, val))
+	}
+	return cmd
+}
+
+type failingUpdateDS struct {
+	*local.LocalDataSource
+}
+
+// UpdateAPBinding fails unconditionally.
+func (f *failingUpdateDS) UpdateAPBinding(_ *ap_binding_proto.APBinding) (*ap_binding_proto.APBinding, error) {
+	return nil, errors.New("fake update failure")
+}
+
+func newFakeDataSource(t *testing.T, cfg *config.Config) datasource.DataSource {
+	configLoader, err := config.NewMemoryLoader(cfg)
+	require.Nil(t, err)
+	lds, err := local.NewLocalDataSource(configLoader)
+	require.Nil(t, err)
+	return lds
+}
+
+func defaultConfig() *config.Config {
+	return &config.Config{
+		TrustZones: []*trust_zone_proto.TrustZone{
+			fixtures.TrustZone("tz1"),
+			fixtures.TrustZone("tz2"),
+		},
+		AttestationPolicies: []*attestation_policy_proto.AttestationPolicy{
+			fixtures.AttestationPolicy("ap1"),
+			fixtures.AttestationPolicy("ap2"),
+		},
+		APBindings: []*ap_binding_proto.APBinding{
+			fixtures.APBinding("apb1"),
+		},
+		Federations: []*federation_proto.Federation{
+			fixtures.Federation("fed1"),
+			fixtures.Federation("fed2"),
+		},
+		Plugins: fixtures.Plugins("plugins1"),
+	}
+}

--- a/cmd/cofidectl/cmd/apbinding/apbinding_test.go
+++ b/cmd/cofidectl/cmd/apbinding/apbinding_test.go
@@ -5,6 +5,7 @@ package apbinding
 
 import (
 	"errors"
+	"strings"
 	"testing"
 
 	ap_binding_proto "github.com/cofide/cofide-api-sdk/gen/go/proto/ap_binding/v1alpha1"
@@ -42,6 +43,21 @@ func TestAPBindingCommand_updateAPBinding(t *testing.T) {
 			wantCheck: func(t *testing.T, binding *ap_binding_proto.APBinding) {
 				require.Len(t, binding.GetFederations(), 1)
 				assert.Equal(t, "tz2-id", binding.GetFederations()[0].GetTrustZoneId())
+			},
+		},
+		{
+			name:                  "update federates-with multiple values",
+			trustZoneName:         "tz1",
+			attestationPolicyName: "ap1",
+			flags:                 map[string]string{"federates-with": "tz2,tz3"},
+			wantCheck: func(t *testing.T, binding *ap_binding_proto.APBinding) {
+				require.Len(t, binding.GetFederations(), 2)
+				tzIDs := []string{
+					binding.GetFederations()[0].GetTrustZoneId(),
+					binding.GetFederations()[1].GetTrustZoneId(),
+				}
+				assert.Contains(t, tzIDs, "tz2-id")
+				assert.Contains(t, tzIDs, "tz3-id")
 			},
 		},
 		{
@@ -130,9 +146,10 @@ func TestAPBindingCommand_updateAPBinding(t *testing.T) {
 				attestationPolicy: tt.attestationPolicyName,
 			}
 			if val, ok := tt.flags["federates-with"]; ok {
-				opts.federatesWith = []string{val}
 				if val == "" {
 					opts.federatesWith = []string{}
+				} else {
+					opts.federatesWith = strings.Split(val, ",")
 				}
 			}
 			if val, ok := tt.flags["clear-federations"]; ok && val == "true" {
@@ -202,6 +219,7 @@ func defaultConfig() *config.Config {
 		TrustZones: []*trust_zone_proto.TrustZone{
 			fixtures.TrustZone("tz1"),
 			fixtures.TrustZone("tz2"),
+			fixtures.TrustZone("tz3"),
 		},
 		AttestationPolicies: []*attestation_policy_proto.AttestationPolicy{
 			fixtures.AttestationPolicy("ap1"),
@@ -213,6 +231,7 @@ func defaultConfig() *config.Config {
 		Federations: []*federation_proto.Federation{
 			fixtures.Federation("fed1"),
 			fixtures.Federation("fed2"),
+			fixtures.Federation("fed3"),
 		},
 		Plugins: fixtures.Plugins("plugins1"),
 	}

--- a/cmd/cofidectl/cmd/apbinding/apbinding_test.go
+++ b/cmd/cofidectl/cmd/apbinding/apbinding_test.go
@@ -183,6 +183,132 @@ func TestAPBindingCommand_updateAPBinding(t *testing.T) {
 	}
 }
 
+func TestAPBindingCommand_addAPBinding(t *testing.T) {
+	tests := []struct {
+		name                  string
+		trustZoneName         string
+		attestationPolicyName string
+		federatesWith         []string
+		injectFailure         bool
+		wantErr               bool
+		wantErrMessage        string
+		wantCheck             func(t *testing.T, binding *ap_binding_proto.APBinding)
+	}{
+		{
+			name:                  "add binding with no federations",
+			trustZoneName:         "tz1",
+			attestationPolicyName: "ap2",
+			wantCheck: func(t *testing.T, binding *ap_binding_proto.APBinding) {
+				assert.Empty(t, binding.GetFederations())
+			},
+		},
+		{
+			name:                  "add binding with single federation",
+			trustZoneName:         "tz1",
+			attestationPolicyName: "ap2",
+			federatesWith:         []string{"tz2"},
+			wantCheck: func(t *testing.T, binding *ap_binding_proto.APBinding) {
+				require.Len(t, binding.GetFederations(), 1)
+				assert.Equal(t, "tz2-id", binding.GetFederations()[0].GetTrustZoneId())
+			},
+		},
+		{
+			name:                  "add binding with multiple federations",
+			trustZoneName:         "tz1",
+			attestationPolicyName: "ap2",
+			federatesWith:         []string{"tz2", "tz3"},
+			wantCheck: func(t *testing.T, binding *ap_binding_proto.APBinding) {
+				require.Len(t, binding.GetFederations(), 2)
+				tzIDs := []string{
+					binding.GetFederations()[0].GetTrustZoneId(),
+					binding.GetFederations()[1].GetTrustZoneId(),
+				}
+				assert.Contains(t, tzIDs, "tz2-id")
+				assert.Contains(t, tzIDs, "tz3-id")
+			},
+		},
+		{
+			name:                  "non-existent trust zone",
+			trustZoneName:         "tz-missing",
+			attestationPolicyName: "ap2",
+			federatesWith:         []string{"tz2"},
+			wantErr:               true,
+			wantErrMessage:        "failed to find trust zone tz-missing in local config",
+		},
+		{
+			name:                  "non-existent attestation policy",
+			trustZoneName:         "tz1",
+			attestationPolicyName: "ap-missing",
+			federatesWith:         []string{"tz2"},
+			wantErr:               true,
+			wantErrMessage:        "failed to find attestation policy ap-missing in local config",
+		},
+		{
+			name:                  "invalid federated trust zone",
+			trustZoneName:         "tz1",
+			attestationPolicyName: "ap2",
+			federatesWith:         []string{"tz-missing"},
+			wantErr:               true,
+			wantErrMessage:        "federated trust zone not found: tz-missing",
+		},
+		{
+			name:                  "datastore failure",
+			trustZoneName:         "tz1",
+			attestationPolicyName: "ap2",
+			injectFailure:         true,
+			wantErr:               true,
+			wantErrMessage:        "fake add failure",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ds := newFakeDataSource(t, defaultConfig())
+			if tt.injectFailure {
+				ds = &failingAddDS{LocalDataSource: ds.(*local.LocalDataSource)}
+			}
+
+			opts := AddOpts{
+				trustZone:         tt.trustZoneName,
+				attestationPolicy: tt.attestationPolicyName,
+				federatesWith:     tt.federatesWith,
+			}
+
+			c := APBindingCommand{}
+			err := c.addAPBinding(opts, ds)
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.ErrorContains(t, err, tt.wantErrMessage)
+			} else {
+				require.NoError(t, err)
+				tz, err := ds.GetTrustZoneByName(tt.trustZoneName)
+				require.NoError(t, err)
+				ap, err := ds.GetAttestationPolicyByName(tt.attestationPolicyName)
+				require.NoError(t, err)
+				bindings, err := ds.ListAPBindings(nil)
+				require.NoError(t, err)
+				var binding *ap_binding_proto.APBinding
+				for _, b := range bindings {
+					if b.GetTrustZoneId() == tz.GetId() && b.GetPolicyId() == ap.GetId() {
+						binding = b
+						break
+					}
+				}
+				require.NotNil(t, binding)
+				tt.wantCheck(t, binding)
+			}
+		})
+	}
+}
+
+type failingAddDS struct {
+	*local.LocalDataSource
+}
+
+// AddAPBinding fails unconditionally.
+func (f *failingAddDS) AddAPBinding(_ *ap_binding_proto.APBinding) (*ap_binding_proto.APBinding, error) {
+	return nil, errors.New("fake add failure")
+}
+
 func buildUpdateCmd(flags map[string]string) *cobra.Command {
 	opts := updateOpts{}
 	cmd := &cobra.Command{}

--- a/cmd/cofidectl/cmd/apbinding/apbinding_test.go
+++ b/cmd/cofidectl/cmd/apbinding/apbinding_test.go
@@ -45,13 +45,21 @@ func TestAPBindingCommand_updateAPBinding(t *testing.T) {
 			},
 		},
 		{
-			name:                  "clear federations with empty list",
+			name:                  "clear federations with --clear-federations",
 			trustZoneName:         "tz1",
 			attestationPolicyName: "ap1",
-			flags:                 map[string]string{"federates-with": ""},
+			flags:                 map[string]string{"clear-federations": "true"},
 			wantCheck: func(t *testing.T, binding *ap_binding_proto.APBinding) {
 				assert.Empty(t, binding.GetFederations())
 			},
+		},
+		{
+			name:                  "conflicting flags returns error",
+			trustZoneName:         "tz1",
+			attestationPolicyName: "ap1",
+			flags:                 map[string]string{"federates-with": "tz2", "clear-federations": "true"},
+			wantErr:               true,
+			wantErrMessage:        "cannot simultaneously specify --federates-with and --clear-federations",
 		},
 		{
 			name:                  "no flags set leaves binding unchanged",
@@ -127,6 +135,9 @@ func TestAPBindingCommand_updateAPBinding(t *testing.T) {
 					opts.federatesWith = []string{}
 				}
 			}
+			if val, ok := tt.flags["clear-federations"]; ok && val == "true" {
+				opts.clearFederations = true
+			}
 
 			c := APBindingCommand{}
 			err := c.updateAPBinding(opts, cmd, ds)
@@ -162,6 +173,7 @@ func buildUpdateCmd(flags map[string]string) *cobra.Command {
 	f.StringVar(&opts.trustZone, "trust-zone", "", "")
 	f.StringVar(&opts.attestationPolicy, "attestation-policy", "", "")
 	f.StringSliceVar(&opts.federatesWith, "federates-with", nil, "")
+	f.BoolVar(&opts.clearFederations, "clear-federations", false, "")
 	for name, val := range flags {
 		cobra.CheckErr(cmd.Flags().Set(name, val))
 	}

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	buf.build/go/protoyaml v0.6.0
 	cuelang.org/go v0.16.0
 	github.com/briandowns/spinner v1.23.2
-	github.com/cofide/cofide-api-sdk v0.49.1-0.20260409224258-618b37cad96c
+	github.com/cofide/cofide-api-sdk v0.50.0
 	github.com/fatih/color v1.19.0
 	github.com/gofrs/flock v0.13.0
 	github.com/google/go-cmp v0.7.0

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	buf.build/go/protoyaml v0.6.0
 	cuelang.org/go v0.16.0
 	github.com/briandowns/spinner v1.23.2
-	github.com/cofide/cofide-api-sdk v0.49.0
+	github.com/cofide/cofide-api-sdk v0.49.1-0.20260409224258-618b37cad96c
 	github.com/fatih/color v1.19.0
 	github.com/gofrs/flock v0.13.0
 	github.com/google/go-cmp v0.7.0

--- a/go.sum
+++ b/go.sum
@@ -64,6 +64,10 @@ github.com/cockroachdb/apd/v3 v3.2.1 h1:U+8j7t0axsIgvQUqthuNm82HIrYXodOV2iWLWtEa
 github.com/cockroachdb/apd/v3 v3.2.1/go.mod h1:klXJcjp+FffLTHlhIG69tezTDvdP065naDsHzKhYSqc=
 github.com/cofide/cofide-api-sdk v0.49.0 h1:27J79VscBmmfWxoUb+x85pG6aV2d5XObzv+koqyG8Rw=
 github.com/cofide/cofide-api-sdk v0.49.0/go.mod h1:lHl7fJc8dM3wediPtxEG8evomrU5R4R0nn0TH/PnIu0=
+github.com/cofide/cofide-api-sdk v0.49.1-0.20260409222726-a48944e56cff h1:/xIr4rASiIQzHPu9LsovmtBYII8N8tJkiH+wwEpVNpg=
+github.com/cofide/cofide-api-sdk v0.49.1-0.20260409222726-a48944e56cff/go.mod h1:o0K5DNBsBFtmEzfgP3/28tyJVEwvOUsWmjLUHStr7cI=
+github.com/cofide/cofide-api-sdk v0.49.1-0.20260409224258-618b37cad96c h1:atpexbyabN5IMTz5/Um13REJnaxHnfli57XhZt7A7ww=
+github.com/cofide/cofide-api-sdk v0.49.1-0.20260409224258-618b37cad96c/go.mod h1:o0K5DNBsBFtmEzfgP3/28tyJVEwvOUsWmjLUHStr7cI=
 github.com/containerd/containerd v1.7.30 h1:/2vezDpLDVGGmkUXmlNPLCCNKHJ5BbC5tJB5JNzQhqE=
 github.com/containerd/containerd v1.7.30/go.mod h1:fek494vwJClULlTpExsmOyKCMUAbuVjlFsJQc4/j44M=
 github.com/containerd/errdefs v0.3.0 h1:FSZgGOeK4yuT/+DnF07/Olde/q4KBoMsaamhXxIMDp4=

--- a/go.sum
+++ b/go.sum
@@ -68,6 +68,8 @@ github.com/cofide/cofide-api-sdk v0.49.1-0.20260409222726-a48944e56cff h1:/xIr4r
 github.com/cofide/cofide-api-sdk v0.49.1-0.20260409222726-a48944e56cff/go.mod h1:o0K5DNBsBFtmEzfgP3/28tyJVEwvOUsWmjLUHStr7cI=
 github.com/cofide/cofide-api-sdk v0.49.1-0.20260409224258-618b37cad96c h1:atpexbyabN5IMTz5/Um13REJnaxHnfli57XhZt7A7ww=
 github.com/cofide/cofide-api-sdk v0.49.1-0.20260409224258-618b37cad96c/go.mod h1:o0K5DNBsBFtmEzfgP3/28tyJVEwvOUsWmjLUHStr7cI=
+github.com/cofide/cofide-api-sdk v0.50.0 h1:qGFlFKNqf/tmt2GsDYLNnYdiZXLHOh+a7M1PArENCpo=
+github.com/cofide/cofide-api-sdk v0.50.0/go.mod h1:o0K5DNBsBFtmEzfgP3/28tyJVEwvOUsWmjLUHStr7cI=
 github.com/containerd/containerd v1.7.30 h1:/2vezDpLDVGGmkUXmlNPLCCNKHJ5BbC5tJB5JNzQhqE=
 github.com/containerd/containerd v1.7.30/go.mod h1:fek494vwJClULlTpExsmOyKCMUAbuVjlFsJQc4/j44M=
 github.com/containerd/errdefs v0.3.0 h1:FSZgGOeK4yuT/+DnF07/Olde/q4KBoMsaamhXxIMDp4=

--- a/internal/pkg/test/fixtures/fixtures.go
+++ b/internal/pkg/test/fixtures/fixtures.go
@@ -356,6 +356,11 @@ var federationFixtures map[string]*federation_proto.Federation = map[string]*fed
 		TrustZoneId:       StringPtr("tz2-id"),
 		RemoteTrustZoneId: StringPtr("tz1-id"),
 	},
+	"fed3": {
+		Id:                StringPtr("fed3-id"),
+		TrustZoneId:       StringPtr("tz1-id"),
+		RemoteTrustZoneId: StringPtr("tz3-id"),
+	},
 }
 
 var pluginConfigFixtures map[string]*structpb.Struct = map[string]*structpb.Struct{

--- a/pkg/plugin/datasource/interface.go
+++ b/pkg/plugin/datasource/interface.go
@@ -40,6 +40,7 @@ type DataSource interface {
 	AddAPBinding(binding *ap_binding_proto.APBinding) (*ap_binding_proto.APBinding, error)
 	DestroyAPBinding(id string) error
 	ListAPBindings(filter *datasourcepb.ListAPBindingsRequest_Filter) ([]*ap_binding_proto.APBinding, error)
+	UpdateAPBinding(binding *ap_binding_proto.APBinding) (*ap_binding_proto.APBinding, error)
 
 	AddFederation(federation *federation_proto.Federation) (*federation_proto.Federation, error)
 	DestroyFederation(id string) error

--- a/pkg/plugin/datasource/plugin.go
+++ b/pkg/plugin/datasource/plugin.go
@@ -220,6 +220,15 @@ func (c *DataSourcePluginClientGRPC) ListAPBindings(filter *cofidectl_proto.List
 	return resp.Bindings, nil
 }
 
+func (c *DataSourcePluginClientGRPC) UpdateAPBinding(binding *ap_binding_proto.APBinding) (*ap_binding_proto.APBinding, error) {
+	resp, err := c.client.UpdateAPBinding(c.ctx, &cofidectl_proto.UpdateAPBindingRequest{Binding: binding})
+	if err != nil {
+		return nil, err
+	}
+
+	return resp.Binding, nil
+}
+
 func (c *DataSourcePluginClientGRPC) AddFederation(federation *federation_proto.Federation) (*federation_proto.Federation, error) {
 	resp, err := c.client.AddFederation(c.ctx, &cofidectl_proto.AddFederationRequest{Federation: federation})
 	if err != nil {
@@ -414,6 +423,14 @@ func (s *GRPCServer) ListAPBindings(_ context.Context, req *cofidectl_proto.List
 		return nil, err
 	}
 	return &cofidectl_proto.ListAPBindingsResponse{Bindings: bindings}, nil
+}
+
+func (s *GRPCServer) UpdateAPBinding(_ context.Context, req *cofidectl_proto.UpdateAPBindingRequest) (*cofidectl_proto.UpdateAPBindingResponse, error) {
+	binding, err := s.Impl.UpdateAPBinding(req.Binding)
+	if err != nil {
+		return nil, err
+	}
+	return &cofidectl_proto.UpdateAPBindingResponse{Binding: binding}, nil
 }
 
 func (s *GRPCServer) AddFederation(_ context.Context, req *cofidectl_proto.AddFederationRequest) (*cofidectl_proto.AddFederationResponse, error) {

--- a/pkg/plugin/local/local.go
+++ b/pkg/plugin/local/local.go
@@ -541,6 +541,70 @@ func (lds *LocalDataSource) ListAPBindings(filter *datasourcepb.ListAPBindingsRe
 	return bindings, nil
 }
 
+func (lds *LocalDataSource) UpdateAPBinding(binding *ap_binding_proto.APBinding) (*ap_binding_proto.APBinding, error) {
+	id := binding.GetId()
+
+	for i, current := range lds.config.APBindings {
+		if current.GetId() == id {
+			if err := validateAPBindingUpdate(current, binding); err != nil {
+				return nil, err
+			}
+
+			remoteTzs := map[string]bool{}
+			for _, federation := range lds.config.Federations {
+				if federation.GetTrustZoneId() == binding.GetTrustZoneId() {
+					remoteTzs[federation.GetRemoteTrustZoneId()] = true
+				}
+			}
+
+			for _, remoteTz := range binding.Federations {
+				if remoteTz.GetTrustZoneId() == binding.GetTrustZoneId() {
+					return nil, fmt.Errorf("attestation policy %s federates with its own trust zone %s", binding.GetPolicyId(), binding.GetTrustZoneId())
+				}
+				if _, ok := remoteTzs[remoteTz.GetTrustZoneId()]; !ok {
+					if _, ok := lds.config.GetTrustZoneByID(remoteTz.GetTrustZoneId()); !ok {
+						return nil, fmt.Errorf("attestation policy %s federates with unknown trust zone %s", binding.GetPolicyId(), remoteTz.GetTrustZoneId())
+					}
+					return nil, fmt.Errorf("attestation policy %s federates with %s but trust zone %s does not", binding.GetPolicyId(), remoteTz.GetTrustZoneId(), binding.GetTrustZoneId())
+				}
+			}
+
+			binding, err := proto.CloneAPBinding(binding)
+			if err != nil {
+				return nil, err
+			}
+
+			lds.config.APBindings[i] = binding
+
+			if err := lds.updateDataFile(); err != nil {
+				return nil, fmt.Errorf("failed to update attestation policy binding %s in local config: %s", id, err)
+			}
+
+			return proto.CloneAPBinding(binding)
+		}
+	}
+
+	return nil, fmt.Errorf("failed to find attestation policy binding %s in local config", id)
+}
+
+func validateAPBindingUpdate(current, new *ap_binding_proto.APBinding) error {
+	id := current.GetId()
+
+	if new.GetId() != current.GetId() {
+		return fmt.Errorf("cannot update id for existing attestation policy binding %s", id)
+	}
+
+	if new.GetTrustZoneId() != current.GetTrustZoneId() {
+		return fmt.Errorf("cannot update trust zone for existing attestation policy binding %s", id)
+	}
+
+	if new.GetPolicyId() != current.GetPolicyId() {
+		return fmt.Errorf("cannot update attestation policy for existing attestation policy binding %s", id)
+	}
+
+	return nil
+}
+
 func (lds *LocalDataSource) AddFederation(federationProto *federation_proto.Federation) (*federation_proto.Federation, error) {
 	if federationProto.GetId() != "" {
 		return nil, fmt.Errorf("federation %s should not have an ID set, this will be auto generated", federationProto.GetId())

--- a/pkg/plugin/local/local.go
+++ b/pkg/plugin/local/local.go
@@ -482,13 +482,13 @@ func (lds *LocalDataSource) AddAPBinding(binding *ap_binding_proto.APBinding) (*
 	for _, remoteTz := range binding.Federations {
 		if remoteTz.GetTrustZoneId() == binding.GetTrustZoneId() {
 			// Is this a problem?
-			return nil, fmt.Errorf("attestation policy %s federates with its own trust zone %s", binding.GetPolicyId(), binding.GetTrustZoneId())
+			return nil, fmt.Errorf("attestation policy binding %s federates with its own trust zone %s", binding.GetId(), binding.GetTrustZoneId())
 		}
 		if _, ok := remoteTzs[remoteTz.GetTrustZoneId()]; !ok {
 			if _, ok := lds.config.GetTrustZoneByID(remoteTz.GetTrustZoneId()); !ok {
-				return nil, fmt.Errorf("attestation policy %s federates with unknown trust zone %s", binding.GetPolicyId(), remoteTz.GetTrustZoneId())
+				return nil, fmt.Errorf("attestation policy binding %s federates with unknown trust zone %s", binding.GetId(), remoteTz.GetTrustZoneId())
 			} else {
-				return nil, fmt.Errorf("attestation policy %s federates with %s but trust zone %s does not", binding.GetPolicyId(), remoteTz.GetTrustZoneId(), binding.GetTrustZoneId())
+				return nil, fmt.Errorf("attestation policy binding %s federates with %s but trust zone %s does not", binding.GetId(), remoteTz.GetTrustZoneId(), binding.GetTrustZoneId())
 			}
 		}
 	}
@@ -559,13 +559,13 @@ func (lds *LocalDataSource) UpdateAPBinding(binding *ap_binding_proto.APBinding)
 
 			for _, remoteTz := range binding.Federations {
 				if remoteTz.GetTrustZoneId() == binding.GetTrustZoneId() {
-					return nil, fmt.Errorf("attestation policy %s federates with its own trust zone %s", binding.GetPolicyId(), binding.GetTrustZoneId())
+					return nil, fmt.Errorf("attestation policy binding %s federates with its own trust zone %s", binding.GetId(), binding.GetTrustZoneId())
 				}
 				if _, ok := remoteTzs[remoteTz.GetTrustZoneId()]; !ok {
 					if _, ok := lds.config.GetTrustZoneByID(remoteTz.GetTrustZoneId()); !ok {
-						return nil, fmt.Errorf("attestation policy %s federates with unknown trust zone %s", binding.GetPolicyId(), remoteTz.GetTrustZoneId())
+						return nil, fmt.Errorf("attestation policy binding %s federates with unknown trust zone %s", binding.GetId(), remoteTz.GetTrustZoneId())
 					}
-					return nil, fmt.Errorf("attestation policy %s federates with %s but trust zone %s does not", binding.GetPolicyId(), remoteTz.GetTrustZoneId(), binding.GetTrustZoneId())
+					return nil, fmt.Errorf("attestation policy binding %s federates with %s but trust zone %s does not", binding.GetId(), remoteTz.GetTrustZoneId(), binding.GetTrustZoneId())
 				}
 			}
 

--- a/pkg/plugin/local/local_test.go
+++ b/pkg/plugin/local/local_test.go
@@ -5,6 +5,7 @@ package local
 
 import (
 	"context"
+	"regexp"
 	"slices"
 	"testing"
 
@@ -1028,10 +1029,10 @@ func TestLocalDataSource_ListAttestationPolicies(t *testing.T) {
 func TestLocalDataSource_AddAPBinding(t *testing.T) {
 	t.Parallel()
 	tests := []struct {
-		name          string
-		binding       *ap_binding_proto.APBinding
-		wantErr       bool
-		wantErrString string
+		name                 string
+		binding              *ap_binding_proto.APBinding
+		wantErr              bool
+		wantErrStringPattern string
 	}{
 		{
 			name: "success",
@@ -1056,8 +1057,8 @@ func TestLocalDataSource_AddAPBinding(t *testing.T) {
 				TrustZoneId: fixtures.StringPtr("invalid"),
 				PolicyId:    fixtures.StringPtr("ap2"),
 			},
-			wantErr:       true,
-			wantErrString: "failed to find trust zone invalid in local config",
+			wantErr:              true,
+			wantErrStringPattern: "failed to find trust zone invalid in local config",
 		},
 		{
 			name: "invalid policy",
@@ -1065,8 +1066,8 @@ func TestLocalDataSource_AddAPBinding(t *testing.T) {
 				TrustZoneId: fixtures.StringPtr("tz1-id"),
 				PolicyId:    fixtures.StringPtr("invalid"),
 			},
-			wantErr:       true,
-			wantErrString: "failed to find attestation policy invalid in local config",
+			wantErr:              true,
+			wantErrStringPattern: "failed to find attestation policy invalid in local config",
 		},
 		{
 			name: "federates with self",
@@ -1075,8 +1076,8 @@ func TestLocalDataSource_AddAPBinding(t *testing.T) {
 				PolicyId:    fixtures.StringPtr("ap2-id"),
 				Federations: []*ap_binding_proto.APBindingFederation{{TrustZoneId: fixtures.StringPtr("tz1-id")}},
 			},
-			wantErr:       true,
-			wantErrString: "attestation policy ap2-id federates with its own trust zone tz1-id",
+			wantErr:              true,
+			wantErrStringPattern: "attestation policy binding [a-z0-9\\-]+ federates with its own trust zone tz1-id",
 		},
 		{
 			name: "federates with invalid tz",
@@ -1085,8 +1086,8 @@ func TestLocalDataSource_AddAPBinding(t *testing.T) {
 				PolicyId:    fixtures.StringPtr("ap2-id"),
 				Federations: []*ap_binding_proto.APBindingFederation{{TrustZoneId: fixtures.StringPtr("invalid")}},
 			},
-			wantErr:       true,
-			wantErrString: "attestation policy ap2-id federates with unknown trust zone invalid",
+			wantErr:              true,
+			wantErrStringPattern: "attestation policy binding [a-z0-9\\-]+ federates with unknown trust zone invalid",
 		},
 		{
 			name: "federates with unfederated tz",
@@ -1095,8 +1096,8 @@ func TestLocalDataSource_AddAPBinding(t *testing.T) {
 				PolicyId:    fixtures.StringPtr("ap2-id"),
 				Federations: []*ap_binding_proto.APBindingFederation{{TrustZoneId: fixtures.StringPtr("tz3-id")}},
 			},
-			wantErr:       true,
-			wantErrString: "attestation policy ap2-id federates with tz3-id but trust zone tz1-id does not",
+			wantErr:              true,
+			wantErrStringPattern: "attestation policy binding [a-z0-9\\-]+ federates with tz3-id but trust zone tz1-id does not",
 		},
 	}
 	for _, tt := range tests {
@@ -1127,7 +1128,8 @@ func TestLocalDataSource_AddAPBinding(t *testing.T) {
 			got, err := lds.AddAPBinding(tt.binding)
 			if tt.wantErr {
 				require.Error(t, err)
-				assert.EqualError(t, err, tt.wantErrString)
+				assert.Regexp(t, regexp.MustCompile(tt.wantErrStringPattern), err.Error())
+				//assert.EqualError(t, err, tt.wantErrString)
 			} else {
 				require.Nil(t, err)
 				tt.binding.Id = got.Id


### PR DESCRIPTION
Part of https://github.com/cofide/cofidectl/issues/424

Depends on https://github.com/cofide/cofide-api-sdk/pull/201

Makes it possible to update attestation policy bindings using the cofidectl CLI.