### PR TITLE
Fix federation status check when cluster has no context

### DIFF
--- a/cmd/cofidectl/cmd/federation/federation.go
+++ b/cmd/cofidectl/cmd/federation/federation.go
@@ -159,6 +159,9 @@ func checkFederationStatus(ctx context.Context, ds datasource.DataSource, kubeCo
 			}
 			return "Unknown", err.Error(), nil
 		}
+		if cluster.GetKubernetesContext() == "" {
+			return "Unknown", "no kubernetes context for cluster", nil
+		}
 
 		if deployed, err := helm.IsClusterDeployed(ctx, cluster, kubeConfig); err != nil {
 			return "", "", err

--- a/cmd/cofidectl/cmd/federation/federation.go
+++ b/cmd/cofidectl/cmd/federation/federation.go
@@ -160,7 +160,7 @@ func checkFederationStatus(ctx context.Context, ds datasource.DataSource, kubeCo
 			return "Unknown", err.Error(), nil
 		}
 		if cluster.GetKubernetesContext() == "" {
-			return "Unknown", "no kubernetes context for cluster", nil
+			return "Unknown", fmt.Sprintf("no kubernetes context for cluster %q in trust zone %q", cluster.GetName(), tz.GetName()), nil
 		}
 
 		if deployed, err := helm.IsClusterDeployed(ctx, cluster, kubeConfig); err != nil {


### PR DESCRIPTION
When a cluster has no context the federation status cannot be checked - so status should be "Unknown"