### PR TITLE
Set recommended node pruning default values

### DIFF
--- a/internal/pkg/trustprovider/trustprovider.go
+++ b/internal/pkg/trustprovider/trustprovider.go
@@ -52,6 +52,8 @@ func (tp *TrustProvider) getValues() error {
 				"enabled":  true,
 				"audience": []string{"spire-server"},
 			},
+			PruneAttestedNodesExpiredFor: "24h",
+			PruneTOFUNodes:               false,
 		}
 	default:
 		return fmt.Errorf("an unknown trust provider kind was specified: %s", tp.Kind)
@@ -66,8 +68,10 @@ type TrustProviderAgentConfig struct {
 }
 
 type TrustProviderServerConfig struct {
-	NodeAttestor       string
-	NodeAttestorConfig map[string]any
+	NodeAttestor                 string
+	NodeAttestorConfig           map[string]any
+	PruneAttestedNodesExpiredFor string
+	PruneTOFUNodes               bool
 }
 
 // GetTrustProviderKindFromProfile returns the valid kind of trust provider for the

--- a/pkg/provider/helm/values.go
+++ b/pkg/provider/helm/values.go
@@ -442,8 +442,10 @@ func (s *spireServerValues) generateValues() (map[string]any, error) {
 			"controllerManager": map[string]any{
 				"enabled": s.controllerManagerEnabled,
 			},
-			"fullnameOverride": s.fullnameOverride,
-			"logLevel":         s.logLevel,
+			"fullnameOverride":             s.fullnameOverride,
+			"logLevel":                     s.logLevel,
+			"pruneAttestedNodesExpiredFor": s.serverConfig.PruneAttestedNodesExpiredFor,
+			"pruneTOFUNodes":               s.serverConfig.PruneTOFUNodes,
 			"nodeAttestor": map[string]any{
 				s.serverConfig.NodeAttestor: s.serverConfig.NodeAttestorConfig,
 			},

--- a/pkg/provider/helm/values_test.go
+++ b/pkg/provider/helm/values_test.go
@@ -122,6 +122,8 @@ func TestHelmValuesGenerator_GenerateValues_success(t *testing.T) {
 							"enabled":  true,
 						},
 					},
+					"pruneAttestedNodesExpiredFor": "24h",
+					"pruneTOFUNodes":               false,
 					"service": Values{
 						"type": "LoadBalancer",
 					},
@@ -231,6 +233,8 @@ func TestHelmValuesGenerator_GenerateValues_success(t *testing.T) {
 							"enabled":  true,
 						},
 					},
+					"pruneAttestedNodesExpiredFor": "24h",
+					"pruneTOFUNodes":               false,
 					"service": Values{
 						"type": "LoadBalancer",
 					},
@@ -345,6 +349,8 @@ func TestHelmValuesGenerator_GenerateValues_success(t *testing.T) {
 							"enabled":  true,
 						},
 					},
+					"pruneAttestedNodesExpiredFor": "24h",
+					"pruneTOFUNodes":               false,
 					"service": Values{
 						"type": "LoadBalancer",
 					},
@@ -429,6 +435,8 @@ func TestHelmValuesGenerator_GenerateValues_success(t *testing.T) {
 							"enabled":  true,
 						},
 					},
+					"pruneAttestedNodesExpiredFor": "24h",
+					"pruneTOFUNodes":               false,
 					"service": Values{
 						"type": "LoadBalancer",
 					},
@@ -665,6 +673,8 @@ func TestHelmValuesGenerator_GenerateValues_AdditionalValues(t *testing.T) {
 							"enabled":  true,
 						},
 					},
+					"pruneAttestedNodesExpiredFor": "24h",
+					"pruneTOFUNodes":               false,
 					"service": Values{
 						"type": "LoadBalancer",
 					},
@@ -758,6 +768,8 @@ func TestHelmValuesGenerator_GenerateValues_AdditionalValues(t *testing.T) {
 							"enabled":  true,
 						},
 					},
+					"pruneAttestedNodesExpiredFor": "24h",
+					"pruneTOFUNodes":               false,
 					"service": Values{
 						"type": "LoadBalancer",
 					},
@@ -1584,6 +1596,8 @@ func TestSpireServerValues_GenerateValues(t *testing.T) {
 						"enabled":  true,
 						"audience": []string{"spire-server"},
 					},
+					PruneAttestedNodesExpiredFor: "24h",
+					PruneTOFUNodes:               false,
 				},
 				serviceType: "LoadBalancer",
 			},
@@ -1594,9 +1608,11 @@ func TestSpireServerValues_GenerateValues(t *testing.T) {
 					"controllerManager": map[string]any{
 						"enabled": true,
 					},
-					"enabled":          true,
-					"fullnameOverride": "spire-server",
-					"logLevel":         "DEBUG",
+					"enabled":                      true,
+					"fullnameOverride":             "spire-server",
+					"logLevel":                     "DEBUG",
+					"pruneAttestedNodesExpiredFor": "24h",
+					"pruneTOFUNodes":               false,
 					"nodeAttestor": Values{
 						"k8sPSAT": Values{
 							"audience": []string{"spire-server"},


### PR DESCRIPTION
Sets recommended node pruning default values.

For documentation on the node pruning defaults see https://github.com/cofide/connect-docs/pull/110

The default chosen here is based on the only attestor being enabled by default being the k8s past one. If a user has other types of nodes (e.g. standalone EC2 instances attested using aws_iid that may have long windows of downtime) then the user would update this as well as updating the helm values to enable that attestor.