### PR TITLE
fix: bump Go to 1.26.4

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/cofide/cofidectl
 
-go 1.26.3
+go 1.26.4
 
 require (
 	buf.build/go/protoyaml v0.7.0


### PR DESCRIPTION
    Vulnerability #1: GO-2026-5039
        Arbitrary inputs are included in errors without any escaping in
        net/textproto
      More info: https://pkg.go.dev/vuln/GO-2026-5039
      Standard library
        Found in: net/textproto@go1.26.3
        Fixed in: net/textproto@go1.26.4
        Example traces found:
    Error:       #1: internal/pkg/test/utils/utils.go:17:27: utils.Base64Decode calls io.ReadAll, which eventually calls textproto.Reader.ReadMIMEHeader
    
    Vulnerability #2: GO-2026-5038
        Quadratic complexity in WordDecoder.DecodeHeader in mime
      More info: https://pkg.go.dev/vuln/GO-2026-5038
      Standard library
        Found in: mime@go1.26.3
        Fixed in: mime@go1.26.4
        Example traces found:
    Error:       #1: internal/pkg/workload/workload.go:262:11: workload.getDebugContainerLogs calls rest.Request.Stream, which eventually calls mime.WordDecoder.DecodeHeader
    
    Vulnerability #3: GO-2026-5037
        Inefficient candidate hostname parsing in crypto/x509
      More info: https://pkg.go.dev/vuln/GO-2026-5037
      Standard library
        Found in: crypto/x509@go1.26.3
        Fixed in: crypto/x509@go1.26.4
        Example traces found:
