### PR TITLE
chore: update Go to 1.26.5

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/cofide/cofidectl
 
-go 1.26.4
+go 1.26.5
 
 require (
 	buf.build/go/protoyaml v0.7.0


### PR DESCRIPTION
Fixes:

Vulnerability #1: GO-2026-5856
    Invoking Encrypted Client Hello privacy leak in crypto/tls
  More info: https://pkg.go.dev/vuln/GO-2026-5856
