### PR TITLE
chore: bump Go to 1.25.6

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/cofide/cofidectl
 
-go 1.26.5
+go 1.26.6
 
 require (
 	buf.build/go/protoyaml v0.7.0


### PR DESCRIPTION
Fixes:

GO-2026-6218
    Avoid quadratic complexity in resolvePath in net/url
    More info: https://pkg.go.dev/vuln/GO-2026-6218

GO-2026-6091
    Fix Javascript regexp context tracking in html/template
    More info: https://pkg.go.dev/vuln/GO-2026-6091

GO-2026-6090
    Limit handshake messages we are willing to accept post-handshake in
    crypto/tls
    More info: https://pkg.go.dev/vuln/GO-2026-6090

GO-2026-6088
    Add recursion depth guard during decode in encoding/xml
    More info: https://pkg.go.dev/vuln/GO-2026-6088

GO-2026-5972
    Enforce maximum recursion depth in encoding/asn1
    More info: https://pkg.go.dev/vuln/GO-2026-5972

GO-2026-5026
    Invoking failure to reject ASCII-only Punycode-encoded labels in
    golang.org/x/net/idna
    More info: https://pkg.go.dev/vuln/GO-2026-5026
